### PR TITLE
feat: add repository scaffolding and research documents

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,0 +1,44 @@
+name: Issue
+description: Track work with explicit acceptance criteria.
+title: "[Issue]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to capture the required issue details.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Short, single-paragraph summary.
+      placeholder: What is the change or problem?
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Goal
+      description: What is broken or what outcome is needed?
+    validations:
+      required: true
+  - type: checkboxes
+    id: acceptance_obvious
+    attributes:
+      label: Acceptance criteria clarity
+      options:
+        - label: Criteria are obvious (docs-only or trivial change)
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria (if not obvious)
+      description: If criteria are obvious, write "Obvious" with a short note.
+      placeholder: List explicit criteria or success conditions.
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation / Evidence
+      description: How will completion be verified?
+    validations:
+      required: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-# Compiled class file
+# Compiled class files
 *.class
 
-# Log file
+# Log files
 *.log
 
 # BlueJ files
@@ -10,7 +10,7 @@
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 
-# Package Files #
+# Package Files
 *.jar
 *.war
 *.nar
@@ -19,6 +19,65 @@
 *.tar.gz
 *.rar
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# Virtual machine crash logs
 hs_err_pid*
 replay_pid*
+
+# Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+
+# Gradle
+.gradle/
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+# IntelliJ IDEA
+.idea/
+*.iws
+*.iml
+*.ipr
+out/
+
+# Eclipse
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+# NetBeans
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+# VS Code
+.vscode/
+
+# macOS
+.DS_Store
+
+# Environments
+.env
+.envrc
+
+# Cursor
+.cursorignore
+.cursorindexingignore

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD013": false,
+  "MD024": { "siblings_only": true }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Agent Instructions
+
+<!-- include: docs/standards-and-conventions.md -->
+<!-- include: ./docs/repository-standards.md -->
+
+## User Overrides (Optional)
+
+If `~/AGENTS.md` exists and is readable, load it and apply it as a
+user-specific overlay for this session. If it cannot be read, say so
+briefly and continue.
+
+## Canonical Standards
+
+This repository follows the canonical standards and conventions in the
+`standards-and-conventions` repository.
+
+Resolve the local path (preferred):
+- `../standards-and-conventions`
+
+If the local path is unavailable, use the canonical web source:
+- https://github.com/wphillipmoore/standards-and-conventions
+
+If the canonical standards cannot be retrieved, treat it as a fatal
+exception and stop.
+
+## Shared Skills
+
+Replace `<standards-repo-path>` with the resolved local path when available.
+- Load all skills from: `<standards-repo-path>/skills/**/SKILL.md`
+- Treat every skill found under that directory as available and active.
+
+## Local Overrides
+
+None.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,158 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Documentation Strategy
+
+This repository uses two complementary approaches for AI agent guidance:
+
+- **AGENTS.md**: Generic AI agent instructions using include directives to force documentation indexing. Contains canonical standards references, shared skills loading, and user override support.
+- **CLAUDE.md** (this file): Claude Code-specific guidance with prescriptive commands, architecture details, and development workflows optimized for `/init`.
+
+### Integration Approach
+
+**For Claude Code** (`/init` command):
+1. Read CLAUDE.md (this file) first for optimized quick-start guidance
+2. Process include directives to load repository standards
+3. Reference AGENTS.md for shared skills and canonical standards location
+4. Apply layered standards: canonical → project-specific → user overrides
+
+**For other AI agents** (Codex, generic LLMs):
+1. Read AGENTS.md first as the primary entry point
+2. Process include directives to load all referenced documentation
+3. Resolve canonical standards repo path (local or GitHub)
+4. Load shared skills from standards repo
+5. Apply user overrides from `~/AGENTS.md` if present
+
+**Key differences**:
+- **CLAUDE.md**: Prescriptive, command-focused, optimized for `/init`
+- **AGENTS.md**: Declarative, include-directive-driven, forces full documentation indexing
+
+Both files share the same underlying standards via include directives, ensuring consistency across all AI agents working in this repository.
+
+### Best Practices for Dual-File Approach
+
+**What goes in AGENTS.md**:
+- Include directives for documentation indexing
+- Canonical standards repository references
+- Shared skills loading instructions
+- User override mechanisms
+- Minimal, declarative content
+
+**What goes in CLAUDE.md**:
+- Claude Code-specific quick-start commands
+- Detailed architecture and design patterns
+- Implementation notes and common workflows
+- Integration guidance between the two files
+- More verbose, prescriptive content
+
+**What goes in neither (use includes instead)**:
+- Repository standards (keep in `docs/repository-standards.md`)
+- Canonical standards (reference external repo)
+- Project-specific conventions (keep in referenced docs)
+
+**Maintenance strategy**:
+- Update standards in source files, not in AGENTS.md or CLAUDE.md
+- Use include directives to pull in shared content
+- Keep AGENTS.md minimal and CLAUDE.md focused on Claude Code workflows
+- Test both entry points when updating documentation structure
+
+<!-- include: docs/standards-and-conventions.md -->
+<!-- include: docs/repository-standards.md -->
+
+## Project Overview
+
+This is a Java port of `pymqrest`, providing a Java wrapper for the IBM MQ administrative REST API. The project will provide a Java mapping layer for MQ REST API attribute translations and command metadata.
+
+**Project name**: TBD (this folder name is a placeholder)
+
+**Status**: Pre-alpha (initial setup)
+
+**Canonical Standards**: This repository follows standards at https://github.com/wphillipmoore/standards-and-conventions (local path: `../standards-and-conventions` if available)
+
+## Development Commands
+
+### Environment Setup
+
+TBD - build tooling and Java version requirements to be determined.
+
+### Validation
+
+TBD - validation suite to be determined. Will include:
+- Build compilation
+- Static analysis / linting
+- Markdown standards checking
+- Commit message validation
+- Security audit
+- Unit tests with coverage requirement
+
+### Testing
+
+TBD - testing framework and commands to be determined.
+
+### Linting and Formatting
+
+TBD - Java linting and formatting tools to be determined.
+
+## Architecture
+
+TBD - architecture to be determined during porting from pymqrest.
+
+The Python project (`pymqrest`) provides the reference architecture:
+- Session management (authentication, base URL construction, request/response handling)
+- Command methods (MQSC command wrappers)
+- Attribute mapping (MQSC ↔ PCF ↔ idiomatic name translations)
+- Mapping data (qualifier and attribute mappings)
+- Exception hierarchy
+
+## Repository Standards Quick Reference
+
+The include directives at the top of this file load the full repository standards. Key highlights for quick reference:
+
+**Pre-flight Checklist**:
+- Check current branch: `git status -sb`
+- If on `develop`, create `feature/*` branch or get explicit approval
+- Enable git hooks: `git config core.hooksPath scripts/git-hooks`
+
+See `docs/repository-standards.md` for complete details.
+
+## Documentation Indexing Strategy
+
+This repository uses `<!-- include: path/to/file.md -->` directives to force documentation indexing. When you encounter these directives:
+
+1. **Read the referenced files** to understand the full context
+2. **Apply layered standards** in order:
+   - Canonical standards (from `standards-and-conventions` repo)
+   - Project-specific standards (`docs/repository-standards.md`)
+   - User overrides (`~/AGENTS.md` if present)
+3. **Load shared skills** from `<standards-repo-path>/skills/**/SKILL.md`
+
+The include directives appear in:
+- `AGENTS.md` - Includes repository standards and conventions
+- `CLAUDE.md` - Includes same standards for Claude Code
+- `docs/standards-and-conventions.md` - Includes canonical standards reference
+
+This approach ensures all AI agents (Codex, Claude, etc.) have access to the same foundational documentation.
+
+## Documentation Structure
+
+- `README.md` - Project overview and quick start
+- `AGENTS.md` - Generic AI agent instructions with include directives
+- `CLAUDE.md` - This file, Claude Code-specific guidance
+- `docs/repository-standards.md` - Project-specific standards (included from AGENTS.md)
+- `docs/standards-and-conventions.md` - Canonical standards reference (includes external repo)
+
+## Key References
+
+**Canonical Standards**: https://github.com/wphillipmoore/standards-and-conventions
+- Local path (preferred): `../standards-and-conventions`
+- Load all skills from: `<standards-repo-path>/skills/**/SKILL.md`
+
+**Reference implementation**: `../pymqrest` (Python version)
+
+**External Documentation**:
+- IBM MQ 9.4 administrative REST API
+- MQSC command reference
+- PCF command formats
+
+**User Overrides**: `~/AGENTS.md` (optional, applied if present and readable)

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,45 @@
+[changelog]
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
+"""
+body = """
+
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="develop-v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | split(pat="\n") | first | trim }}\
+    {% endfor %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug fixes" },
+  { message = "^doc", group = "Documentation" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Refactoring" },
+  { message = "^style", group = "Styling" },
+  { message = "^test", group = "Testing" },
+  { message = "^ci", group = "CI" },
+  { message = "^chore", skip = true },
+]
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "develop-v[0-9].*"
+skip_tags = ""
+sort_commits = "oldest"

--- a/docs/plans/2026-02-12-project-naming.md
+++ b/docs/plans/2026-02-12-project-naming.md
@@ -1,0 +1,138 @@
+# Project naming decision
+
+## Table of Contents
+
+- [Results](#results)
+- [Reasoning](#reasoning)
+- [Options not chosen](#options-not-chosen)
+- [Open questions](#open-questions)
+- [Dependencies and external constraints](#dependencies-and-external-constraints)
+- [References](#references)
+
+## Results
+
+### Decisions made
+
+- **Project name**: `mq-rest-admin`
+- **GitHub repository name**: `mq-rest-admin`
+- **Maven artifactId**: `mq-rest-admin`
+- **Java package segment**: dot-separated (`mq.rest.admin`), yielding a full
+  package of `{groupId}.mq.rest.admin`
+
+### Deliverables
+
+- Repository to be created on GitHub as `mq-rest-admin`.
+- Open decisions document (`docs/plans/open-decisions.md`) to be updated to
+  reflect the resolved naming items and record the groupId decision when made.
+
+### Open decisions explicitly flagged as unresolved
+
+- **Maven groupId**: depends on whether `io.github.wphillipmoore` or a personal
+  domain (e.g., `dev.pmoore`) is used. This determines the full Java package
+  namespace (e.g., `io.github.wphillipmoore.mq.rest.admin` vs
+  `dev.pmoore.mq.rest.admin`).
+
+## Reasoning
+
+### Key constraints
+
+- **Maven Central coordinates are effectively permanent.** Published artifacts
+  cannot be deleted. Relocation POMs exist but are messy and the old coordinates
+  persist forever.
+- **Java package names cannot contain hyphens.** Hyphens are idiomatic in Maven
+  artifact IDs but forbidden in Java identifiers. The chosen name must work in
+  both contexts.
+- **The MQ REST API has both administrative and messaging endpoints.** The
+  library targets only the administrative portion. The name must not imply
+  broader scope.
+- **Naming should fit the existing IBM MQ ecosystem.** IBM's GitHub organization
+  (`ibm-messaging`) consistently uses the `mq-{purpose}` pattern. Community
+  projects use hyphenated lowercase with `mq` or `ibm-mq` in the name.
+
+### Tradeoffs discussed
+
+- **Brevity vs accuracy**: `mqrest` is shorter and simpler, but overpromises by
+  implying coverage of the entire MQ REST API (admin + messaging). `mq-rest-admin`
+  is longer but accurately scopes the library to administration only.
+- **Hyphen/package mismatch**: `mq-rest-admin` requires a different form for the
+  Java package (`mq.rest.admin`). This is a routine tradeoff in the Java
+  ecosystem -- Jackson, Spring, and JUnit all manage it. The dot-separated form
+  provides natural sub-package boundaries (e.g., `mq.rest.admin.session`,
+  `mq.rest.admin.mapping`).
+
+### Evidence cited
+
+- The IBM MQ REST API documents both `/admin/` and `/messaging/` endpoint
+  families. See `docs/research/admin-rest-api-gap-analysis.md`.
+- pymqrest (the Python reference implementation) already exists, so the claim
+  that `mqrest` would be "the only client library" is false. The name does not
+  need to be language-neutral.
+- IBM's own MQ GitHub repos follow `mq-{purpose}`: `mq-jms-spring`,
+  `mq-mqi-nodejs`, `mq-container`, `mq-metric-samples`. `mq-rest-admin` fits
+  this pattern cleanly.
+- Well-known Java libraries routinely manage the hyphen/package divergence:
+  `jackson-databind` → `com.fasterxml.jackson.databind`, `spring-web` →
+  `org.springframework.web`, `junit-jupiter-api` → `org.junit.jupiter.api`.
+
+## Options not chosen
+
+### `mqrest`
+
+- **Description**: Short, language-neutral name. No hyphen means the artifact ID
+  and package segment would be identical.
+- **Reason not chosen**: Overpromises scope. The MQ REST API includes both
+  administrative and messaging endpoints; this library covers only
+  administration. A user discovering `mqrest` on Maven Central would reasonably
+  expect messaging support.
+- **Status**: Rejected.
+
+### `jmqrest`
+
+- **Description**: Direct analogy to `pymqrest`, using the `j` prefix for Java.
+- **Reason not chosen**: The `j`-prefix convention is not established in the Java
+  ecosystem the way `py`-prefix is for Python. No major Java libraries follow
+  this pattern.
+- **Status**: Rejected.
+
+### `mq-admin-rest-client`
+
+- **Description**: More descriptive, Maven-style artifact name.
+- **Reason not chosen**: Discussed briefly but not carried forward. Overly long
+  and the `-client` suffix is redundant for a library that is inherently a
+  client.
+- **Status**: Not pursued.
+
+### `mq-rest-admin` with concatenated package (`mqrestadmin`)
+
+- **Description**: Same artifact ID but using a single concatenated segment for
+  the Java package rather than dot-separated.
+- **Reason not chosen**: Dot-separated packages (`mq.rest.admin`) provide
+  natural sub-package boundaries and follow the more common convention among
+  multi-word Java libraries (Spring, Jackson, JUnit).
+- **Status**: Rejected in favor of dot-separated form.
+
+## Open questions
+
+- Maven groupId selection (see open decisions above).
+- Whether the library will eventually cover the resource-specific CRUD endpoints
+  (level 2 in `docs/research/admin-rest-api-gap-analysis.md`) in addition to the
+  MQSC endpoint. The name `mq-rest-admin` accommodates both scopes.
+
+## Dependencies and external constraints
+
+- Maven Central namespace verification requires either a DNS TXT record (personal
+  domain) or a temporary GitHub repository (for `io.github.*` namespace).
+- The groupId namespace, once verified, allows publishing under any sub-group
+  without additional verification.
+- GitHub repository name can be changed later (redirects are created), but Maven
+  coordinates cannot.
+
+## References
+
+- `docs/research/mq-java-ecosystem.md` -- ecosystem survey and naming
+  conventions
+- `docs/research/admin-rest-api-gap-analysis.md` -- REST API surface and gap
+  analysis
+- `docs/plans/open-decisions.md` -- remaining open decisions
+- `../standards-and-conventions/docs/foundation/summarize-decisions-protocol.md`
+  -- protocol followed for this document

--- a/docs/plans/open-decisions.md
+++ b/docs/plans/open-decisions.md
@@ -1,0 +1,78 @@
+# Open decisions
+
+## Table of Contents
+
+- [Purpose](#purpose)
+- [Project identity](#project-identity)
+- [Java platform](#java-platform)
+- [Build tooling](#build-tooling)
+- [Code quality and static analysis](#code-quality-and-static-analysis)
+- [Testing](#testing)
+- [Architecture](#architecture)
+- [CI and publishing](#ci-and-publishing)
+- [Validation scripts](#validation-scripts)
+
+## Purpose
+
+Track decisions that must be made before substantive development begins on the
+Java port of pymqrest.
+
+## Project identity
+
+- **Project name**: `mq-rest-admin` (decided 2026-02-12, see
+  `docs/plans/2026-02-12-project-naming.md`).
+- **GitHub repository name**: `mq-rest-admin`.
+- **Maven artifactId**: `mq-rest-admin`.
+- **Maven groupId**: TBD. Depends on namespace choice (`io.github.wphillipmoore`
+  vs personal domain).
+- **Java package**: `{groupId}.mq.rest.admin` (dot-separated form, decided
+  2026-02-12).
+
+## Java platform
+
+- **Minimum Java version**: TBD.
+- **Distribution**: TBD (OpenJDK, Temurin, etc.).
+
+## Build tooling
+
+- **Build tool**: TBD (Maven vs Gradle).
+- **Dependency lock file strategy**: TBD.
+- **Wrapper inclusion**: TBD (Maven Wrapper / Gradle Wrapper).
+
+## Code quality and static analysis
+
+- **Linter / static analysis**: TBD (Checkstyle, SpotBugs, Error Prone, PMD,
+  etc.).
+- **Formatter**: TBD (google-java-format, Spotless, etc.).
+- **Null-safety strategy**: TBD (annotations, Optional, etc.).
+
+## Testing
+
+- **Test framework**: TBD (JUnit 5, TestNG, etc.).
+- **Mocking library**: TBD (Mockito, etc.).
+- **Coverage tool and threshold**: TBD (JaCoCo target percentage).
+- **Integration test strategy**: TBD (same local MQ container as pymqrest).
+
+## Architecture
+
+- **HTTP client library**: TBD (java.net.http, OkHttp, Apache HttpClient, etc.).
+- **JSON library**: TBD (Jackson, Gson, etc.).
+- **API surface style**: TBD (fluent builder, method-per-command mirroring
+  pymqrest, etc.).
+- **Attribute mapping approach**: TBD (port pymqrest mapping pipeline, or
+  redesign for Java idioms).
+- **Exception hierarchy**: TBD (mirror pymqrest or adapt to Java conventions).
+
+## CI and publishing
+
+- **CI platform**: GitHub Actions (consistent with pymqrest).
+- **Publishing target**: TBD (Maven Central, GitHub Packages, etc.).
+- **Publishing mechanism**: TBD (OSSRH, Central Portal, etc.).
+
+## Validation scripts
+
+- **Local validation command**: TBD (equivalent of pymqrest's
+  `validate_local.py`).
+- **Docs-only validation**: TBD (markdownlint is already available).
+- **Git hooks**: TBD (scripts/git-hooks directory created, hooks not yet
+  written).

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -1,0 +1,51 @@
+# Repository Standards
+
+## Table of Contents
+
+- [Pre-flight checklist](#pre-flight-checklist)
+- [AI co-authors](#ai-co-authors)
+- [Repository profile](#repository-profile)
+- [Local validation](#local-validation)
+- [Tooling requirement](#tooling-requirement)
+- [Merge strategy override](#merge-strategy-override)
+
+## Pre-flight checklist
+
+- Before modifying any files, check the current branch with `git status -sb`.
+- If on `develop`, create a short-lived `feature/*` branch or ask for explicit approval to proceed on `develop`.
+- If approval is granted to work on `develop`, call it out in the response and proceed only for that user-approved scope.
+- Enable repository git hooks before committing: `git config core.hooksPath scripts/git-hooks`.
+
+## AI co-authors
+
+- Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>
+- Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
+
+## Repository profile
+
+- repository_type: library
+- versioning_scheme: library
+- branching_model: library-release
+- release_model: artifact-publishing
+- supported_release_lines: current and previous
+
+## Local validation
+
+TBD - validation commands to be established with Java tooling.
+
+## Tooling requirement
+
+TBD - Java version, build tool, and other requirements to be determined.
+
+Required for daily workflow:
+
+- `markdownlint` (required for docs validation and PR pre-submission)
+
+## Merge strategy override
+
+- Feature, bugfix, and chore PRs targeting `develop` use squash merges (`--squash`).
+- Release PRs targeting `main` use regular merges (`--merge`) to preserve shared
+  ancestry between `main` and `develop`.
+- Auto-merge commands:
+  - Feature PRs: `gh pr merge --auto --squash --delete-branch`
+  - Release PRs: `gh pr merge --auto --merge --delete-branch`

--- a/docs/research/admin-rest-api-gap-analysis.md
+++ b/docs/research/admin-rest-api-gap-analysis.md
@@ -1,0 +1,170 @@
+# IBM MQ administrative REST API gap analysis
+
+## Table of Contents
+
+- [Purpose](#purpose)
+- [The administrative REST API](#the-administrative-rest-api)
+- [REST API endpoints](#rest-api-endpoints)
+- [The MQSC endpoint in detail](#the-mqsc-endpoint-in-detail)
+- [Authentication](#authentication)
+- [REST API version history](#rest-api-version-history)
+- [Existing client libraries for the admin REST API](#existing-client-libraries-for-the-admin-rest-api)
+- [Dependency implications](#dependency-implications)
+- [Scope considerations](#scope-considerations)
+
+## Purpose
+
+Analyze the IBM MQ administrative REST API surface, confirm that no existing
+Java client library covers it, and document the implications for project
+dependencies and scope. Research conducted 2026-02-12.
+
+## The administrative REST API
+
+The REST API is served by the **mqweb server** (an embedded Liberty server),
+typically on port 9443 (HTTPS). Base URL pattern:
+
+```text
+https://{host}:{port}/ibmmq/rest/v{version}/
+```
+
+This is completely independent from the native MQ wire protocol (port 1414) used
+by `com.ibm.mq.allclient` and PCF.
+
+## REST API endpoints
+
+### Administrative endpoints
+
+| Endpoint | Methods | Purpose |
+|---|---|---|
+| `/admin/action/qmgr/{qmgrName}/mqsc` | POST | Execute MQSC commands |
+| `/admin/installation` | GET | Query MQ installations |
+| `/admin/qmgr` | GET | List queue managers and status |
+| `/admin/qmgr/{qmgrName}/queue` | GET, POST, PATCH, DELETE | CRUD on queues |
+| `/admin/qmgr/{qmgrName}/channel` | GET | Query channels |
+| `/admin/qmgr/{qmgrName}/subscription` | GET | Query subscriptions |
+| `/admin/mft/agent` | GET | Query MFT agents |
+| `/admin/mft/call` | GET, POST | Manage MFT calls |
+| `/admin/mft/monitor` | GET, POST | Manage MFT monitors |
+| `/admin/mft/transfer` | GET, POST | Manage MFT transfers |
+| `/login` | POST, DELETE | Authentication (LTPA token) |
+
+### Messaging endpoints (separate from admin)
+
+| Endpoint | Methods | Purpose |
+|---|---|---|
+| `/messaging/qmgr/{qmgrName}/queue/{qName}/message` | POST, DELETE | Send/receive messages |
+| `/messaging/qmgr/{qmgrName}/topic/{topicString}/message` | POST | Publish to topic |
+
+## The MQSC endpoint in detail
+
+**URL**: `POST /ibmmq/rest/v2/admin/action/qmgr/{qmgrName}/mqsc`
+
+Two modes are available on this single endpoint:
+
+### runCommand (plain text MQSC)
+
+```json
+{
+  "type": "runCommand",
+  "parameters": {
+    "command": "DISPLAY QLOCAL(MY.QUEUE) ALL"
+  }
+}
+```
+
+Response contains text strings in `commandResponse[].text[]`.
+
+### runCommandJSON (structured JSON MQSC)
+
+```json
+{
+  "type": "runCommandJSON",
+  "command": "display",
+  "qualifier": "qlocal",
+  "name": "MY.QUEUE",
+  "responseParameters": ["all"]
+}
+```
+
+Response contains structured JSON (easier to parse programmatically). This is
+the mode that pymqrest uses exclusively.
+
+### Required HTTP headers
+
+- `Content-Type: application/json`
+- `ibm-mq-rest-csrf-token: <any value>` (CSRF protection; value can be blank)
+- `Authorization: Basic <base64>` (or LTPA token cookie from `/login`)
+
+## Authentication
+
+Two mechanisms are supported:
+
+1. **Basic authentication**: Standard HTTP Basic auth header. User must be in
+   `MQWebAdmin`, `MQWebAdminRO`, or `MQWebUser` role.
+2. **LTPA token**: POST to `/login` to obtain an LTPA cookie, then include the
+   cookie in subsequent requests.
+
+pymqrest currently supports basic auth and CSRF token handling.
+
+## REST API version history
+
+| Version | Introduced In | Notes |
+|---|---|---|
+| v1 | IBM MQ 9.0.1 | Initial REST API |
+| v2 | IBM MQ 9.1.5 | Additional features |
+| v3 | IBM MQ 9.3.0 | Current version |
+
+The `/admin/action/qmgr/{qmgrName}/mqsc` endpoint has been available since at
+least v1. IBM provides an OpenAPI/Swagger spec at the
+`/rest/v1/openapi.json` endpoint on the mqweb server.
+
+## Existing client libraries for the admin REST API
+
+### Java
+
+**None.** No Java library on Maven Central, GitHub, or elsewhere wraps the IBM
+MQ administrative REST API.
+
+### Other languages
+
+| Project | Language | Approach |
+|---|---|---|
+| pymqrest | Python | Full client library (this project's reference implementation) |
+| mq-dotnet-administration-with-mqrestapi | C# / .NET | IBM sample code, raw HTTP calls |
+| mq-sample-web-ui | JavaScript | IBM sample web page, raw fetch calls |
+| mq-mcp-server | Python | IBM MCP server, raw httpx calls |
+
+IBM's own projects (MCP server, .NET sample) use raw HTTP calls, confirming
+there is no official SDK in any language.
+
+## Dependency implications
+
+This project does **not** need `com.ibm.mq.allclient` or any other IBM MQ
+client library. The admin REST API is standard HTTP/JSON. Required dependencies
+are:
+
+1. **HTTP client**: `java.net.http.HttpClient` (built into JDK 11+), OkHttp, or
+   Apache HttpClient.
+2. **JSON library**: Jackson, Gson, or similar.
+
+No native code, JNI bindings, or MQ-specific transport libraries are required.
+
+## Scope considerations
+
+The admin REST API offers two levels of functionality:
+
+### Level 1: MQSC endpoint (pymqrest parity)
+
+The `/admin/action/qmgr/{qmgrName}/mqsc` endpoint with `runCommandJSON` mode.
+This is what pymqrest wraps today and provides access to the full MQSC command
+set.
+
+### Level 2: Resource-specific CRUD endpoints
+
+Dedicated endpoints for queues, channels, subscriptions, and queue manager info.
+These accept direct HTTP verbs (GET, POST, PATCH, DELETE) against resource URLs
+and do not require constructing MQSC command text.
+
+Whether the Java port covers only level 1 (MQSC endpoint, pymqrest parity) or
+also level 2 (resource CRUD endpoints) is an open design decision. Level 2
+endpoints could offer a more idiomatic Java API surface for common operations.

--- a/docs/research/mq-java-ecosystem.md
+++ b/docs/research/mq-java-ecosystem.md
@@ -1,0 +1,185 @@
+# IBM MQ Java ecosystem survey
+
+## Table of Contents
+
+- [Purpose](#purpose)
+- [Official IBM artifacts on Maven Central](#official-ibm-artifacts-on-maven-central)
+- [What each library provides](#what-each-library-provides)
+- [PCF: the closest thing to admin in Java](#pcf-the-closest-thing-to-admin-in-java)
+- [Third-party libraries](#third-party-libraries)
+- [IBM GitHub repositories and naming conventions](#ibm-github-repositories-and-naming-conventions)
+- [Published package names across languages](#published-package-names-across-languages)
+- [Community naming conventions](#community-naming-conventions)
+- [Conclusion](#conclusion)
+
+## Purpose
+
+Document the existing IBM MQ Java library ecosystem to inform dependency
+decisions and project naming for the Java port of pymqrest. Research conducted
+2026-02-12.
+
+## Official IBM artifacts on Maven Central
+
+All official IBM MQ Java artifacts are published under groupId `com.ibm.mq`.
+
+| Artifact ID | Latest Version | Purpose |
+|---|---|---|
+| `com.ibm.mq.allclient` | 9.4.3.0 | Uber-JAR: MQ Java + JMS + PCF + Headers |
+| `com.ibm.mq.jakarta.client` | 9.4.3.0 | Jakarta Messaging 3.0 equivalent of allclient |
+| `mq-jms-spring-boot-starter` | 3.5.3 | Spring Boot autoconfiguration for JMS |
+| `mq-jms-spring-testcontainer` | 3.5.3 | Spring test support with Testcontainers |
+| `mq-java-testcontainer` | 1.21.2 | Testcontainers integration for MQ |
+| `wmq.jmsra` | 9.4.3.0 | JMS Resource Adapter (javax) |
+| `wmq.jmsra.ivt` | 9.4.3.0 | JMS RA Installation Verification Test |
+| `wmq.jakarta.jmsra` | 9.4.3.0 | JMS Resource Adapter (jakarta) |
+| `wmq.jakarta.jmsra.ivt` | 9.4.3.0 | Jakarta JMS RA IVT |
+
+There are no separate `com.ibm.mq:com.ibm.mq`, `com.ibm.mq:com.ibm.mq.pcf`,
+or `com.ibm.mq:com.ibm.mq.headers` artifacts on Maven Central. These exist
+only as internal packages within the uber-JARs or as legacy JARs in the MQ
+installation directory (not published to Maven).
+
+## What each library provides
+
+### com.ibm.mq.allclient (the uber-JAR)
+
+Messaging and low-level administration via PCF. Contains:
+
+- IBM MQ classes for Java (`MQQueueManager`, `MQQueue`, `MQMessage`)
+- IBM MQ classes for JMS 2.0 (`MQConnectionFactory`)
+- PCF classes (`PCFMessageAgent`, `PCFMessage`)
+- Headers classes (`MQHeaderList`, `MQRFH2`, `MQCIH`)
+
+**Transport**: Native MQ wire protocol over TCP (default port 1414) or JNI local
+bindings. Does NOT use HTTP/REST. Has no awareness of the mqweb server, port
+9443, or any REST endpoints.
+
+### com.ibm.mq.jakarta.client
+
+Identical in function to allclient, except uses `jakarta.jms.*` package names
+instead of `javax.jms.*`. Supports Jakarta Messaging 3.0. Contains the same
+PCF and Headers packages. Same transport (native MQ protocol, not REST).
+
+### mq-jms-spring-boot-starter
+
+Spring Boot autoconfiguration for JMS messaging with IBM MQ. Source:
+[ibm-messaging/mq-jms-spring](https://github.com/ibm-messaging/mq-jms-spring).
+Auto-creates `ConnectionFactory`, `JmsTemplate`, and `MessageListener` beans
+from `ibm.mq.*` properties. Purely JMS messaging autoconfiguration -- no
+administration capabilities.
+
+### com.ibm.mq.headers (package in allclient)
+
+Helper classes for constructing and parsing MQ message headers (`MQRFH2`,
+`MQCIH`, `MQDLH`, `MQXQH`, etc.). Data-format helpers, not a transport layer.
+
+## PCF: the closest thing to admin in Java
+
+The `com.ibm.mq.pcf` package (bundled inside `allclient.jar`) provides
+Programmable Command Format support for administration.
+
+### How PCF works
+
+1. `PCFMessageAgent` opens a connection to the queue manager (TCP port 1414 or
+   JNI bindings).
+2. It constructs a binary PCF message (`MQCFH` header + parameter structures).
+3. It puts the message onto `SYSTEM.ADMIN.COMMAND.QUEUE`.
+4. The command server on the queue manager reads it, executes the command, and
+   replies.
+5. `PCFMessageAgent` reads the reply.
+
+### PCF vs the REST API
+
+| Aspect | PCF | REST API |
+|---|---|---|
+| Transport | MQ messages via TCP:1414 / JNI | HTTP/HTTPS via mqweb (TCP:9443) |
+| Wire format | Binary PCF structures | JSON over HTTP |
+| Requires | MQ client libraries (native code) | Any HTTP client |
+| Prerequisite | MQ listener + command server | mqweb server (embedded Liberty) |
+| Arbitrary MQSC | Yes, via Escape PCF (`MQCMD_ESCAPE`) | Yes, via `runCommand` / `runCommandJSON` |
+| Response format | Binary PCF (typed) or text (escape) | Structured JSON or text |
+| Age | MQ V5 era (decades old) | MQ 9.0.1 (2017) |
+
+PCF and the admin REST API are completely independent mechanisms. The mqweb
+server likely translates REST requests into PCF internally, but this is opaque.
+
+### Can PCF execute arbitrary MQSC?
+
+Yes, through Escape PCF (`MQCMD_ESCAPE` with `EscapeType` set to `MQET_MQSC`).
+The MQSC text goes in the `EscapeText` parameter. Responses come back as
+unparsed text strings, making programmatic consumption difficult. This is how
+`runmqsc` in client mode works internally.
+
+## Third-party libraries
+
+### fbraem/mqweb
+
+A standalone C++ HTTP server (built on the POCO framework) that exposes its own
+REST API for querying MQ objects. Connects via the native MQI C API, not through
+IBM's REST API. Endpoints like `/api/queue/inquire` translate to PCF commands
+internally. Predates IBM's own REST API. Not relevant as a dependency (C++, own
+API surface).
+
+### IBM MQ MCP Server
+
+IBM's own Model Context Protocol server for LLM integration
+([ibm-messaging/mq-mcp-server](https://github.com/ibm-messaging/mq-mcp-server)).
+Written in Python, calls the admin REST API using raw `httpx` HTTP calls.
+Confirms that IBM themselves have no SDK for the REST API.
+
+### Other
+
+No Java library on Maven Central, GitHub, or elsewhere wraps the IBM MQ
+administrative REST API.
+
+## IBM GitHub repositories and naming conventions
+
+The [ibm-messaging](https://github.com/ibm-messaging) organization (121+
+repositories) uses consistent naming: `mq-{purpose}` or
+`mq-{protocol}-{language}`.
+
+| Repository | Language | Purpose |
+|---|---|---|
+| `mq-jms-spring` | Java | Spring Boot JMS integration |
+| `mq-golang` | Go | Go MQI wrapper |
+| `mq-golang-jms20` | Go | JMS 2.0 style interface for Go |
+| `mq-mqi-nodejs` | JS | Node.js MQI wrapper |
+| `mq-mqi-python` | Python | Python MQI wrapper (`ibmmq` package) |
+| `mq-metric-samples` | Go | Prometheus/CloudWatch metric exporters |
+| `mq-container` | Docker | Container images |
+| `mq-ansible` | Ansible | Ansible roles |
+| `mq-helm` | Helm | Kubernetes Helm charts |
+| `mq-sample-web-ui` | JS | Sample web UI using admin REST API |
+| `mq-dotnet-administration-with-mqrestapi` | .NET | .NET samples for admin REST API |
+
+For MQI wrappers, the pattern is `mq-mqi-{language}`. For other libraries, the
+pattern is `mq-{technology}-{purpose}`.
+
+## Published package names across languages
+
+| Language | Registry | Package Name | GitHub Repo |
+|---|---|---|---|
+| Java | Maven Central | `com.ibm.mq:com.ibm.mq.allclient` | (closed source) |
+| Node.js | npm | `ibmmq` | `ibm-messaging/mq-mqi-nodejs` |
+| Python | PyPI | `ibmmq` | `ibm-messaging/mq-mqi-python` |
+| Go | Go modules | `github.com/ibm-messaging/mq-golang/v5/ibmmq` | `ibm-messaging/mq-golang` |
+
+IBM converged on `ibmmq` (all lowercase, no separators) as the published package
+name across npm, PyPI, and Go.
+
+## Community naming conventions
+
+| Project | Convention | Example |
+|---|---|---|
+| pymqi (Python) | `py` + protocol | Python + MQI = `pymqi` |
+| pymqrest (Python) | `py` + product + interface | Python + MQ + REST = `pymqrest` |
+| mqweb (C++) | product + interface | MQ + web = `mqweb` |
+| Third-party Java | hyphenated, includes `mq` or `ibm-mq` | `mq-java-exporter` |
+
+## Conclusion
+
+Every IBM MQ Java artifact on Maven Central is a messaging client that uses the
+native MQ wire protocol (TCP port 1414 or JNI bindings). None support the
+administrative REST API. IBM does not publish a Java SDK for the admin REST API.
+The gap this project fills is genuine and there is no existing library to extend
+or wrap.

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -1,0 +1,17 @@
+# Standards and Conventions
+
+This repository follows the canonical standards at:
+<https://github.com/wphillipmoore/standards-and-conventions>
+
+## Table of Contents
+
+- [Canonical references](#canonical-references)
+- [Project-specific overlay](#project-specific-overlay)
+
+## Canonical references
+<!-- include: ../standards-and-conventions/docs/standards-and-conventions.md -->
+
+## Project-specific overlay
+
+Project-specific content lives in `docs/repository-standards.md` and is
+included from `AGENTS.md` only.

--- a/standards-and-conventions.md
+++ b/standards-and-conventions.md
@@ -1,0 +1,7 @@
+# Standards Bootstrap
+
+## Table of Contents
+- [Includes](#includes)
+
+## Includes
+<!-- include: docs/standards-and-conventions.md -->


### PR DESCRIPTION
## Summary

- Establish repository structure adapted from pymqrest: CLAUDE.md/AGENTS.md dual-file documentation strategy, canonical standards references, issue templates, markdownlint config, changelog config, Java-specific .gitignore
- Add research documents: MQ Java ecosystem survey, admin REST API gap analysis
- Add planning documents: project naming decision record, open decisions tracker

## Test plan

- [ ] Verify markdownlint passes on all .md files
- [ ] Confirm include directives resolve to canonical standards repo at `../standards-and-conventions`
- [ ] Review naming decision record against summarize-decisions protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)