### PR TITLE
feat: add integration test strategy and MQ dev wrapper scripts

### DIFF
--- a/docs/plans/2026-02-14-integration-test-strategy.md
+++ b/docs/plans/2026-02-14-integration-test-strategy.md
@@ -1,0 +1,91 @@
+# Integration test strategy
+
+**Date**: 2026-02-14
+
+## Decision
+
+Each consuming project (pymqrest, mq-rest-admin, future Go port) runs distinct
+MQ containers isolated via `COMPOSE_PROJECT_NAME` and project-specific host port
+allocation. Shared Docker infrastructure is provided by the `mq-dev-environment`
+repository.
+
+## Context
+
+The `mq-dev-environment` repo provides shared Docker infrastructure: a
+docker-compose.yml with QM1 and QM2, seed scripts for test objects, lifecycle
+scripts (start/seed/verify/stop/reset), and a CI composite action. This is
+already consumed by pymqrest.
+
+Previously, container names, network name, and host ports were hardcoded,
+preventing multiple projects from running integration tests simultaneously.
+
+## Isolation mechanism
+
+### COMPOSE_PROJECT_NAME
+
+Docker Compose uses `COMPOSE_PROJECT_NAME` to prefix container and network names.
+Each project sets a unique project name:
+
+- `pymqrest` (or `mq-dev`, the default)
+- `mq-rest-admin`
+
+This prevents container name collisions when multiple projects run
+simultaneously.
+
+### Port allocation
+
+Each project uses a unique set of host ports with an offset of 10 per project:
+
+| Project | QM1 REST | QM2 REST | QM1 MQ | QM2 MQ |
+|---|---|---|---|---|
+| pymqrest | 9443 (default) | 9444 (default) | 1414 (default) | 1415 (default) |
+| mq-rest-admin | 9453 | 9454 | 1424 | 1425 |
+| Go port (future) | 9463 | 9464 | 1434 | 1435 |
+
+Port configuration is passed via environment variables (`QM1_REST_PORT`,
+`QM2_REST_PORT`, `QM1_MQ_PORT`, `QM2_MQ_PORT`) which docker-compose.yml
+interpolates into the `ports:` mapping.
+
+## Local development
+
+Wrapper scripts in `scripts/dev/mq_*.sh` set the project-specific environment
+variables and delegate to the corresponding `mq-dev-environment` scripts:
+
+- `scripts/dev/mq_start.sh` — start containers on project-specific ports
+- `scripts/dev/mq_seed.sh` — seed MQ objects
+- `scripts/dev/mq_verify.sh` — verify environment readiness
+- `scripts/dev/mq_stop.sh` — stop containers
+- `scripts/dev/mq_reset.sh` — stop containers and remove volumes
+
+The `mq-dev-environment` repo is expected at `../mq-dev-environment` (sibling
+directory) by default, overridable via `MQ_DEV_ENV_PATH`.
+
+## CI
+
+The `mq-dev-environment` composite action (`setup-mq`) accepts `project-name`,
+`qm1-rest-port`, and `qm2-rest-port` inputs. mq-rest-admin's CI workflow will
+pass its project-specific values.
+
+## Java integration test gating
+
+- Integration test files follow the `*IT.java` naming convention
+- `maven-failsafe-plugin` runs them during `mvn verify`
+- Tests are gated by `@EnabledIfEnvironmentVariable` on
+  `MQ_REST_ADMIN_RUN_INTEGRATION` — they are skipped unless the environment
+  variable is set
+- Integration tests are excluded from JaCoCo coverage enforcement (unit tests
+  already achieve 100% line and branch coverage)
+- CI runs integration tests on a single Java version (not the full 17/21/25
+  matrix) to reduce resource usage
+
+## Backward compatibility
+
+All environment variables default to current values. Callers that do not set
+any variables get identical behavior to the pre-parameterization setup:
+
+- Default ports: 9443/9444 (REST), 1414/1415 (MQ)
+- Default project name: `mq-dev`
+
+The only visible change is container naming (from `mq-dev-qm1` to
+`<project>-qm1-1`), but no consumer references containers by name — scripts
+use `docker compose exec <service>`.

--- a/docs/plans/open-decisions.md
+++ b/docs/plans/open-decisions.md
@@ -66,7 +66,10 @@ implemented; remaining items are tooling and infrastructure.
   2026-02-12).
 - **Integration test convention**: `*IT.java` via `maven-failsafe-plugin`
   (decided 2026-02-12).
-- **Integration test strategy**: TBD (same local MQ container as pymqrest).
+- **Integration test strategy**: Each project runs distinct MQ containers via
+  COMPOSE_PROJECT_NAME isolation and project-specific port allocation. Shared
+  infrastructure from mq-dev-environment (decided 2026-02-14, see
+  `docs/plans/2026-02-14-integration-test-strategy.md`).
 
 ## Architecture
 

--- a/scripts/dev/mq_reset.sh
+++ b/scripts/dev/mq_reset.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-dev-environment}"
+
+if [ ! -d "$mq_dev_env" ]; then
+  echo "mq-dev-environment not found at: $mq_dev_env" >&2
+  echo "Clone it as a sibling directory or set MQ_DEV_ENV_PATH." >&2
+  exit 1
+fi
+
+export COMPOSE_PROJECT_NAME=mq-rest-admin
+export QM1_REST_PORT=9453
+export QM2_REST_PORT=9454
+export QM1_MQ_PORT=1424
+export QM2_MQ_PORT=1425
+
+cd "$mq_dev_env"
+exec scripts/mq_reset.sh

--- a/scripts/dev/mq_seed.sh
+++ b/scripts/dev/mq_seed.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-dev-environment}"
+
+if [ ! -d "$mq_dev_env" ]; then
+  echo "mq-dev-environment not found at: $mq_dev_env" >&2
+  echo "Clone it as a sibling directory or set MQ_DEV_ENV_PATH." >&2
+  exit 1
+fi
+
+export COMPOSE_PROJECT_NAME=mq-rest-admin
+export QM1_REST_PORT=9453
+export QM2_REST_PORT=9454
+export QM1_MQ_PORT=1424
+export QM2_MQ_PORT=1425
+
+cd "$mq_dev_env"
+exec scripts/mq_seed.sh

--- a/scripts/dev/mq_start.sh
+++ b/scripts/dev/mq_start.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-dev-environment}"
+
+if [ ! -d "$mq_dev_env" ]; then
+  echo "mq-dev-environment not found at: $mq_dev_env" >&2
+  echo "Clone it as a sibling directory or set MQ_DEV_ENV_PATH." >&2
+  exit 1
+fi
+
+export COMPOSE_PROJECT_NAME=mq-rest-admin
+export QM1_REST_PORT=9453
+export QM2_REST_PORT=9454
+export QM1_MQ_PORT=1424
+export QM2_MQ_PORT=1425
+
+cd "$mq_dev_env"
+exec scripts/mq_start.sh

--- a/scripts/dev/mq_stop.sh
+++ b/scripts/dev/mq_stop.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-dev-environment}"
+
+if [ ! -d "$mq_dev_env" ]; then
+  echo "mq-dev-environment not found at: $mq_dev_env" >&2
+  echo "Clone it as a sibling directory or set MQ_DEV_ENV_PATH." >&2
+  exit 1
+fi
+
+export COMPOSE_PROJECT_NAME=mq-rest-admin
+export QM1_REST_PORT=9453
+export QM2_REST_PORT=9454
+export QM1_MQ_PORT=1424
+export QM2_MQ_PORT=1425
+
+cd "$mq_dev_env"
+exec scripts/mq_stop.sh

--- a/scripts/dev/mq_verify.sh
+++ b/scripts/dev/mq_verify.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-dev-environment}"
+
+if [ ! -d "$mq_dev_env" ]; then
+  echo "mq-dev-environment not found at: $mq_dev_env" >&2
+  echo "Clone it as a sibling directory or set MQ_DEV_ENV_PATH." >&2
+  exit 1
+fi
+
+export COMPOSE_PROJECT_NAME=mq-rest-admin
+export QM1_REST_PORT=9453
+export QM2_REST_PORT=9454
+export QM1_MQ_PORT=1424
+export QM2_MQ_PORT=1425
+
+cd "$mq_dev_env"
+exec scripts/mq_verify.sh


### PR DESCRIPTION
## Summary

- Add decision record documenting per-project container isolation via `COMPOSE_PROJECT_NAME` and project-specific port allocation
- Create 5 wrapper scripts in `scripts/dev/` (`mq_start.sh`, `mq_seed.sh`, `mq_verify.sh`, `mq_stop.sh`, `mq_reset.sh`) that delegate to `mq-dev-environment` with mq-rest-admin-specific ports (9453/9454 REST, 1424/1425 MQ)
- Update `open-decisions.md` to mark integration test strategy as decided

Depends on: wphillipmoore/mq-dev-environment#12 (parameterize docker-compose)

## Test plan

- [ ] Verify `scripts/dev/mq_start.sh` starts containers on ports 9453/9454
- [ ] Verify `scripts/dev/mq_stop.sh` stops the project-specific containers
- [ ] Confirm containers have `mq-rest-admin` project prefix in names

🤖 Generated with [Claude Code](https://claude.com/claude-code)