### PR TITLE
feat: add transport interface and response record

### DIFF
--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/MqRestTransport.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/MqRestTransport.java
@@ -1,0 +1,32 @@
+package io.github.wphillipmoore.mq.rest.admin;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * Transport interface for MQ REST API HTTP communication.
+ *
+ * <p>Mirrors pymqrest's {@code MQRESTTransport} protocol. Implementations handle the actual HTTP
+ * communication and should throw {@link
+ * io.github.wphillipmoore.mq.rest.admin.exception.MqRestTransportException} for network or
+ * connection failures.
+ */
+public interface MqRestTransport {
+
+  /**
+   * Sends a JSON POST request to the MQ REST API.
+   *
+   * @param url fully-qualified URL to send the request to
+   * @param payload JSON-serializable request body
+   * @param headers HTTP headers to include in the request
+   * @param timeout request timeout, or {@code null} for no timeout
+   * @param verifyTls whether to verify TLS certificates
+   * @return the transport response
+   */
+  TransportResponse postJson(
+      String url,
+      Map<String, Object> payload,
+      Map<String, String> headers,
+      Duration timeout,
+      boolean verifyTls);
+}

--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/TransportResponse.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/TransportResponse.java
@@ -1,0 +1,23 @@
+package io.github.wphillipmoore.mq.rest.admin;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable response from an MQ REST API transport operation.
+ *
+ * <p>Mirrors pymqrest's {@code TransportResponse} frozen dataclass. Headers are defensively copied
+ * to guarantee unmodifiability.
+ *
+ * @param statusCode the HTTP status code
+ * @param body the response body text, never null (empty string if no body)
+ * @param headers the response headers, never null, unmodifiable
+ */
+public record TransportResponse(int statusCode, String body, Map<String, String> headers) {
+
+  /** Validates non-null fields and defensively copies headers. */
+  public TransportResponse {
+    Objects.requireNonNull(body, "body");
+    headers = Map.copyOf(Objects.requireNonNull(headers, "headers"));
+  }
+}

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestTransportTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestTransportTest.java
@@ -1,0 +1,27 @@
+package io.github.wphillipmoore.mq.rest.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MqRestTransportTest {
+
+  @Test
+  void stubImplementationSatisfiesContract() {
+    MqRestTransport transport =
+        (url, payload, headers, timeout, verifyTls) -> new TransportResponse(200, "{}", Map.of());
+
+    TransportResponse response =
+        transport.postJson(
+            "https://localhost:9443/ibmmq/rest/v1/admin/qmgr",
+            Map.of("type", "runCommand"),
+            Map.of("Content-Type", "application/json"),
+            Duration.ofSeconds(30),
+            true);
+
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(response.body()).isEqualTo("{}");
+  }
+}

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/TransportResponseTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/TransportResponseTest.java
@@ -1,0 +1,71 @@
+package io.github.wphillipmoore.mq.rest.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TransportResponseTest {
+
+  @Test
+  void constructionWithValidValues() {
+    TransportResponse response =
+        new TransportResponse(200, "{}", Map.of("Content-Type", "application/json"));
+
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(response.body()).isEqualTo("{}");
+    assertThat(response.headers()).containsEntry("Content-Type", "application/json");
+  }
+
+  @Test
+  void nullBodyThrowsNullPointerException() {
+    assertThatThrownBy(() -> new TransportResponse(200, null, Map.of()))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("body");
+  }
+
+  @Test
+  void nullHeadersThrowsNullPointerException() {
+    assertThatThrownBy(() -> new TransportResponse(200, "", null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("headers");
+  }
+
+  @Test
+  void headersAreDefensivelyCopied() {
+    HashMap<String, String> mutableHeaders = new HashMap<>();
+    mutableHeaders.put("X-Key", "original");
+
+    TransportResponse response = new TransportResponse(200, "", mutableHeaders);
+    mutableHeaders.put("X-Key", "modified");
+
+    assertThat(response.headers()).containsEntry("X-Key", "original");
+  }
+
+  @Test
+  void headersAreUnmodifiable() {
+    TransportResponse response = new TransportResponse(200, "", Map.of("X-Key", "value"));
+
+    assertThatThrownBy(() -> response.headers().put("X-New", "value"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void equalityForSameValues() {
+    TransportResponse first = new TransportResponse(200, "body", Map.of("key", "value"));
+    TransportResponse second = new TransportResponse(200, "body", Map.of("key", "value"));
+
+    assertThat(first).isEqualTo(second);
+    assertThat(first.hashCode()).isEqualTo(second.hashCode());
+  }
+
+  @Test
+  void toStringContainsFieldValues() {
+    TransportResponse response = new TransportResponse(404, "not found", Map.of());
+
+    assertThat(response.toString()).contains("404");
+    assertThat(response.toString()).contains("not found");
+  }
+}


### PR DESCRIPTION
## Summary

- Add `TransportResponse` record -- immutable HTTP response with defensive header copying via `Map.copyOf()`
- Add `MqRestTransport` interface -- single `postJson()` method mirroring pymqrest's `MQRESTTransport` protocol
- Full test coverage for record validation, defensive copying, unmodifiability, equality, and interface contract

Step 2 of the implementation sequence from `docs/plans/2026-02-12-tier3-decisions.md`. Defines the HTTP boundary that all session logic depends on, enabling Mockito-based testing without network calls.

## Test plan

- [x] `TransportResponseTest` -- 7 tests covering construction, null validation, defensive copy, unmodifiability, equality, toString
- [x] `MqRestTransportTest` -- 1 test verifying lambda implementation satisfies the interface contract
- [x] `./mvnw verify` passes (Spotless, Checkstyle, JaCoCo 100%, SpotBugs, PMD)

Generated with [Claude Code](https://claude.com/claude-code)