### PR TITLE
feat: add auth types (Credentials sealed interface + records)

### DIFF
--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/auth/BasicAuth.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/auth/BasicAuth.java
@@ -1,0 +1,21 @@
+package io.github.wphillipmoore.mq.rest.admin.auth;
+
+import java.util.Objects;
+
+/**
+ * Basic authentication credentials for the MQ REST API.
+ *
+ * <p>Mirrors pymqrest's {@code BasicAuth} frozen dataclass. Used to construct an {@code
+ * Authorization: Basic} header.
+ *
+ * @param username the username, never null
+ * @param password the password, never null
+ */
+public record BasicAuth(String username, String password) implements Credentials {
+
+  /** Validates that username and password are non-null. */
+  public BasicAuth {
+    Objects.requireNonNull(username, "username");
+    Objects.requireNonNull(password, "password");
+  }
+}

--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/auth/CertificateAuth.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/auth/CertificateAuth.java
@@ -1,0 +1,29 @@
+package io.github.wphillipmoore.mq.rest.admin.auth;
+
+import java.util.Objects;
+
+/**
+ * Certificate-based (mTLS) authentication credentials for the MQ REST API.
+ *
+ * <p>Mirrors pymqrest's {@code CertificateAuth} frozen dataclass. Passed to the transport layer for
+ * mTLS configuration.
+ *
+ * @param certPath path to the client certificate file, never null
+ * @param keyPath path to the private key file, or null if combined with the certificate
+ */
+public record CertificateAuth(String certPath, String keyPath) implements Credentials {
+
+  /** Validates that certPath is non-null. keyPath may be null. */
+  public CertificateAuth {
+    Objects.requireNonNull(certPath, "certPath");
+  }
+
+  /**
+   * Creates certificate credentials with a combined certificate and key file.
+   *
+   * @param certPath path to the combined certificate and key file, never null
+   */
+  public CertificateAuth(String certPath) {
+    this(certPath, null);
+  }
+}

--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/auth/Credentials.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/auth/Credentials.java
@@ -1,0 +1,9 @@
+package io.github.wphillipmoore.mq.rest.admin.auth;
+
+/**
+ * Sealed credential type for MQ REST API authentication.
+ *
+ * <p>Mirrors pymqrest's {@code Credentials} union type. The session dispatches on the concrete type
+ * using {@code instanceof} pattern matching.
+ */
+public sealed interface Credentials permits BasicAuth, LtpaAuth, CertificateAuth {}

--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/auth/LtpaAuth.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/auth/LtpaAuth.java
@@ -1,0 +1,21 @@
+package io.github.wphillipmoore.mq.rest.admin.auth;
+
+import java.util.Objects;
+
+/**
+ * LTPA authentication credentials for the MQ REST API.
+ *
+ * <p>Mirrors pymqrest's {@code LTPAAuth} frozen dataclass. The session performs a login POST at
+ * construction time and stores the {@code LtpaToken2} cookie for subsequent requests.
+ *
+ * @param username the username for LTPA login, never null
+ * @param password the password for LTPA login, never null
+ */
+public record LtpaAuth(String username, String password) implements Credentials {
+
+  /** Validates that username and password are non-null. */
+  public LtpaAuth {
+    Objects.requireNonNull(username, "username");
+    Objects.requireNonNull(password, "password");
+  }
+}

--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/auth/package-info.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/auth/package-info.java
@@ -1,0 +1,2 @@
+/** Credential types for MQ REST API authentication. */
+package io.github.wphillipmoore.mq.rest.admin.auth;

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/auth/BasicAuthTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/auth/BasicAuthTest.java
@@ -1,0 +1,48 @@
+package io.github.wphillipmoore.mq.rest.admin.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class BasicAuthTest {
+
+  @Test
+  void constructionWithValidValues() {
+    BasicAuth auth = new BasicAuth("admin", "secret");
+
+    assertThat(auth.username()).isEqualTo("admin");
+    assertThat(auth.password()).isEqualTo("secret");
+  }
+
+  @Test
+  void nullUsernameThrowsNullPointerException() {
+    assertThatThrownBy(() -> new BasicAuth(null, "secret"))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("username");
+  }
+
+  @Test
+  void nullPasswordThrowsNullPointerException() {
+    assertThatThrownBy(() -> new BasicAuth("admin", null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("password");
+  }
+
+  @Test
+  void equalityForSameValues() {
+    BasicAuth first = new BasicAuth("admin", "secret");
+    BasicAuth second = new BasicAuth("admin", "secret");
+
+    assertThat(first).isEqualTo(second);
+    assertThat(first.hashCode()).isEqualTo(second.hashCode());
+  }
+
+  @Test
+  void toStringContainsFieldValues() {
+    BasicAuth auth = new BasicAuth("admin", "secret");
+
+    assertThat(auth.toString()).contains("admin");
+    assertThat(auth.toString()).contains("secret");
+  }
+}

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/auth/CertificateAuthTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/auth/CertificateAuthTest.java
@@ -1,0 +1,56 @@
+package io.github.wphillipmoore.mq.rest.admin.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class CertificateAuthTest {
+
+  @Test
+  void constructionWithBothPaths() {
+    CertificateAuth auth = new CertificateAuth("/cert.pem", "/key.pem");
+
+    assertThat(auth.certPath()).isEqualTo("/cert.pem");
+    assertThat(auth.keyPath()).isEqualTo("/key.pem");
+  }
+
+  @Test
+  void convenienceConstructorSetsKeyPathToNull() {
+    CertificateAuth auth = new CertificateAuth("/combined.pem");
+
+    assertThat(auth.certPath()).isEqualTo("/combined.pem");
+    assertThat(auth.keyPath()).isNull();
+  }
+
+  @Test
+  void nullCertPathThrowsNullPointerException() {
+    assertThatThrownBy(() -> new CertificateAuth(null, "/key.pem"))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("certPath");
+  }
+
+  @Test
+  void nullKeyPathIsAllowed() {
+    CertificateAuth auth = new CertificateAuth("/cert.pem", null);
+
+    assertThat(auth.keyPath()).isNull();
+  }
+
+  @Test
+  void equalityForSameValues() {
+    CertificateAuth first = new CertificateAuth("/cert.pem", "/key.pem");
+    CertificateAuth second = new CertificateAuth("/cert.pem", "/key.pem");
+
+    assertThat(first).isEqualTo(second);
+    assertThat(first.hashCode()).isEqualTo(second.hashCode());
+  }
+
+  @Test
+  void toStringContainsFieldValues() {
+    CertificateAuth auth = new CertificateAuth("/cert.pem", "/key.pem");
+
+    assertThat(auth.toString()).contains("/cert.pem");
+    assertThat(auth.toString()).contains("/key.pem");
+  }
+}

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/auth/CredentialsTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/auth/CredentialsTest.java
@@ -1,0 +1,33 @@
+package io.github.wphillipmoore.mq.rest.admin.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class CredentialsTest {
+
+  @Test
+  void basicAuthImplementsCredentials() {
+    assertThat(new BasicAuth("user", "pass")).isInstanceOf(Credentials.class);
+  }
+
+  @Test
+  void ltpaAuthImplementsCredentials() {
+    assertThat(new LtpaAuth("user", "pass")).isInstanceOf(Credentials.class);
+  }
+
+  @Test
+  void certificateAuthImplementsCredentials() {
+    assertThat(new CertificateAuth("/cert.pem", "/key.pem")).isInstanceOf(Credentials.class);
+  }
+
+  @Test
+  void sealedInterfacePermitsExactlyThreeTypes() {
+    Class<?>[] permitted = Credentials.class.getPermittedSubclasses();
+
+    assertThat(permitted).hasSize(3);
+    assertThat(permitted)
+        .extracting(Class::getSimpleName)
+        .containsExactlyInAnyOrder("BasicAuth", "LtpaAuth", "CertificateAuth");
+  }
+}

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/auth/LtpaAuthTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/auth/LtpaAuthTest.java
@@ -1,0 +1,48 @@
+package io.github.wphillipmoore.mq.rest.admin.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class LtpaAuthTest {
+
+  @Test
+  void constructionWithValidValues() {
+    LtpaAuth auth = new LtpaAuth("admin", "secret");
+
+    assertThat(auth.username()).isEqualTo("admin");
+    assertThat(auth.password()).isEqualTo("secret");
+  }
+
+  @Test
+  void nullUsernameThrowsNullPointerException() {
+    assertThatThrownBy(() -> new LtpaAuth(null, "secret"))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("username");
+  }
+
+  @Test
+  void nullPasswordThrowsNullPointerException() {
+    assertThatThrownBy(() -> new LtpaAuth("admin", null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("password");
+  }
+
+  @Test
+  void equalityForSameValues() {
+    LtpaAuth first = new LtpaAuth("admin", "secret");
+    LtpaAuth second = new LtpaAuth("admin", "secret");
+
+    assertThat(first).isEqualTo(second);
+    assertThat(first.hashCode()).isEqualTo(second.hashCode());
+  }
+
+  @Test
+  void toStringContainsFieldValues() {
+    LtpaAuth auth = new LtpaAuth("admin", "secret");
+
+    assertThat(auth.toString()).contains("admin");
+    assertThat(auth.toString()).contains("secret");
+  }
+}


### PR DESCRIPTION
Closes #10

## Summary

- Add `Credentials` sealed interface as the credential type for MQ REST API authentication
- Implement `BasicAuth`, `LtpaAuth`, and `CertificateAuth` records with null-safety validation
- `CertificateAuth` includes convenience single-arg constructor for combined cert+key files
- Step 3 of the implementation sequence (after exceptions and transport layer)

## Test plan

- [x] `CredentialsTest` — sealed interface permits exactly three types, all records implement it
- [x] `BasicAuthTest` — construction, null rejection, equality, toString
- [x] `LtpaAuthTest` — construction, null rejection, equality, toString
- [x] `CertificateAuthTest` — both constructors, nullable keyPath, null certPath rejection, equality, toString
- [x] Full `./mvnw verify` passes (Spotless, Checkstyle, 65 tests, JaCoCo 100%, SpotBugs, PMD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)