### PR TITLE
feat: implement attribute mapping pipeline

### DIFF
--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/mapping/AttributeMapper.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/mapping/AttributeMapper.java
@@ -1,0 +1,267 @@
+package io.github.wphillipmoore.mq.rest.admin.mapping;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Translates attributes between snake_case Python-style names and MQSC parameter names.
+ *
+ * <p>Implements a 3-layer mapping pipeline mirroring pymqrest's {@code _map_attributes_internal}:
+ *
+ * <ol>
+ *   <li><b>Key-value map</b> (request only): synthetic attributes that map to both a new key and
+ *       value
+ *   <li><b>Key map</b>: translates attribute names
+ *   <li><b>Value map</b>: translates attribute values for specific keys
+ * </ol>
+ *
+ * <p>Supports both strict mode (throws {@link MappingException} on unknown keys/values) and
+ * permissive mode (records issues but returns mapped results).
+ */
+public final class AttributeMapper {
+
+  private final MappingData data;
+
+  /** Creates a mapper using the default built-in mapping data. */
+  public AttributeMapper() {
+    this(MappingData.loadDefault());
+  }
+
+  /**
+   * Creates a mapper using the provided mapping data.
+   *
+   * @param data the mapping data to use, must not be null
+   * @throws NullPointerException if data is null
+   */
+  public AttributeMapper(MappingData data) {
+    this.data = Objects.requireNonNull(data, "data");
+  }
+
+  /**
+   * Maps request attributes from snake_case to MQSC parameter names.
+   *
+   * @param qualifier the qualifier (e.g., "queue")
+   * @param attributes the input attributes to map
+   * @param strict if true, throws on mapping issues; if false, passes through unmapped attributes
+   * @return mapped attributes
+   * @throws MappingException if strict is true and any attributes cannot be mapped
+   */
+  public Map<String, Object> mapRequestAttributes(
+      String qualifier, Map<String, Object> attributes, boolean strict) {
+    List<MappingIssue> issues = new ArrayList<>();
+    Map<String, Object> result =
+        mapAttributes(qualifier, attributes, MappingDirection.REQUEST, null, issues);
+    if (strict && !issues.isEmpty()) {
+      throw new MappingException(issues);
+    }
+    return result;
+  }
+
+  /**
+   * Maps response attributes from MQSC parameter names to snake_case.
+   *
+   * @param qualifier the qualifier (e.g., "queue")
+   * @param attributes the input attributes to map
+   * @param strict if true, throws on mapping issues; if false, passes through unmapped attributes
+   * @return mapped attributes
+   * @throws MappingException if strict is true and any attributes cannot be mapped
+   */
+  public Map<String, Object> mapResponseAttributes(
+      String qualifier, Map<String, Object> attributes, boolean strict) {
+    List<MappingIssue> issues = new ArrayList<>();
+    Map<String, Object> result =
+        mapAttributes(qualifier, attributes, MappingDirection.RESPONSE, null, issues);
+    if (strict && !issues.isEmpty()) {
+      throw new MappingException(issues);
+    }
+    return result;
+  }
+
+  /**
+   * Maps a list of response objects, tracking the object index in any issues.
+   *
+   * @param qualifier the qualifier (e.g., "queue")
+   * @param objects the list of response objects to map
+   * @param strict if true, throws after mapping all objects if any issues found
+   * @return list of mapped objects
+   * @throws MappingException if strict is true and any attributes cannot be mapped
+   */
+  public List<Map<String, Object>> mapResponseList(
+      String qualifier, List<Map<String, Object>> objects, boolean strict) {
+    List<MappingIssue> allIssues = new ArrayList<>();
+    List<Map<String, Object>> result = new ArrayList<>();
+    for (int i = 0; i < objects.size(); i++) {
+      result.add(mapAttributes(qualifier, objects.get(i), MappingDirection.RESPONSE, i, allIssues));
+    }
+    if (strict && !allIssues.isEmpty()) {
+      throw new MappingException(allIssues);
+    }
+    return result;
+  }
+
+  private Map<String, Object> mapAttributes(
+      String qualifier,
+      Map<String, Object> attributes,
+      MappingDirection direction,
+      Integer objectIndex,
+      List<MappingIssue> issues) {
+    if (!data.hasQualifier(qualifier)) {
+      issues.add(
+          new MappingIssue(
+              direction, MappingReason.UNKNOWN_QUALIFIER, qualifier, null, objectIndex, qualifier));
+      return new LinkedHashMap<>(attributes);
+    }
+
+    Map<String, Object> qualifierData = data.getQualifierData(qualifier);
+    Map<String, String> keyMap =
+        getStringMap(
+            qualifierData,
+            direction == MappingDirection.REQUEST ? "request_key_map" : "response_key_map");
+    Map<String, Object> valueMap =
+        getNestedMap(
+            qualifierData,
+            direction == MappingDirection.REQUEST ? "request_value_map" : "response_value_map");
+    Map<String, Object> keyValueMap =
+        direction == MappingDirection.REQUEST
+            ? getNestedMap(qualifierData, "request_key_value_map")
+            : Map.of();
+
+    Map<String, Object> result = new LinkedHashMap<>();
+
+    for (Map.Entry<String, Object> entry : attributes.entrySet()) {
+      String attrName = entry.getKey();
+      Object attrValue = entry.getValue();
+
+      // Layer 1: Key-value map (request only)
+      if (keyValueMap.containsKey(attrName)) {
+        if (attrValue instanceof String) {
+          Object mapped = mapKeyValue(keyValueMap, attrName, (String) attrValue);
+          if (mapped != null) {
+            @SuppressWarnings("unchecked")
+            Map<String, String> target = (Map<String, String>) mapped;
+            result.put(target.get("key"), target.get("value"));
+            continue;
+          }
+        }
+        // Unknown value in key-value map
+        issues.add(
+            new MappingIssue(
+                direction,
+                MappingReason.UNKNOWN_VALUE,
+                attrName,
+                attrValue,
+                objectIndex,
+                qualifier));
+        result.put(attrName, attrValue);
+        continue;
+      }
+
+      // Layer 2: Key map
+      if (!keyMap.containsKey(attrName)) {
+        issues.add(
+            new MappingIssue(
+                direction, MappingReason.UNKNOWN_KEY, attrName, attrValue, objectIndex, qualifier));
+        result.put(attrName, attrValue);
+        continue;
+      }
+      String mappedKey = keyMap.get(attrName);
+
+      // Layer 3: Value map
+      Object mappedValue =
+          mapValue(valueMap, attrName, attrValue, direction, issues, objectIndex, qualifier);
+      result.put(mappedKey, mappedValue);
+    }
+
+    return result;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Object mapKeyValue(
+      Map<String, Object> keyValueMap, String attrName, String attrValue) {
+    Object attrEntry = keyValueMap.get(attrName);
+    if (!(attrEntry instanceof Map)) {
+      return null;
+    }
+    Map<String, Object> valueMappings = (Map<String, Object>) attrEntry;
+    Object target = valueMappings.get(attrValue);
+    return target instanceof Map ? target : null;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Object mapValue(
+      Map<String, Object> valueMap,
+      String attrName,
+      Object attrValue,
+      MappingDirection direction,
+      List<MappingIssue> issues,
+      Integer objectIndex,
+      String qualifier) {
+    if (!valueMap.containsKey(attrName)) {
+      return attrValue;
+    }
+    Object mappingEntry = valueMap.get(attrName);
+    if (!(mappingEntry instanceof Map)) {
+      return attrValue;
+    }
+    Map<String, String> valueMappings = (Map<String, String>) mappingEntry;
+
+    if (attrValue instanceof String) {
+      String mapped = valueMappings.get(attrValue);
+      if (mapped != null) {
+        return mapped;
+      }
+      issues.add(
+          new MappingIssue(
+              direction, MappingReason.UNKNOWN_VALUE, attrName, attrValue, objectIndex, qualifier));
+      return attrValue;
+    }
+    if (attrValue instanceof List) {
+      List<Object> listValue = (List<Object>) attrValue;
+      List<Object> mappedList = new ArrayList<>();
+      for (Object element : listValue) {
+        if (element instanceof String) {
+          String mapped = valueMappings.get(element);
+          if (mapped != null) {
+            mappedList.add(mapped);
+          } else {
+            issues.add(
+                new MappingIssue(
+                    direction,
+                    MappingReason.UNKNOWN_VALUE,
+                    attrName,
+                    element,
+                    objectIndex,
+                    qualifier));
+            mappedList.add(element);
+          }
+        } else {
+          mappedList.add(element);
+        }
+      }
+      return mappedList;
+    }
+    return attrValue;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, String> getStringMap(Map<String, Object> data, String key) {
+    Object value = data.get(key);
+    if (value instanceof Map) {
+      Map<String, String> result = new LinkedHashMap<>();
+      for (Map.Entry<String, Object> entry : ((Map<String, Object>) value).entrySet()) {
+        result.put(entry.getKey(), String.valueOf(entry.getValue()));
+      }
+      return result;
+    }
+    return Map.of();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> getNestedMap(Map<String, Object> data, String key) {
+    Object value = data.get(key);
+    return value instanceof Map ? (Map<String, Object>) value : Map.of();
+  }
+}

--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/mapping/MappingData.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/mapping/MappingData.java
@@ -1,0 +1,264 @@
+package io.github.wphillipmoore.mq.rest.admin.mapping;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Mapping data for attribute translation between snake_case and MQSC parameter names.
+ *
+ * <p>Wraps a structured map loaded from JSON (via Gson). Provides typed accessors for {@link
+ * AttributeMapper} and supports override merging via {@link MappingOverrideMode}.
+ *
+ * <p>The JSON structure mirrors pymqrest's {@code MAPPING_DATA} dictionary, containing {@code
+ * commands} (command-to-qualifier lookup) and {@code qualifiers} (per-qualifier mapping sub-maps).
+ */
+public final class MappingData {
+
+  private static final String RESOURCE_NAME = "mapping-data.json";
+  private static final Set<String> VALID_TOP_LEVEL_KEYS = Set.of("commands", "qualifiers");
+  private static final Gson GSON = new Gson();
+  private static final Type MAP_TYPE = new TypeToken<Map<String, Object>>() {}.getType();
+
+  private final Map<String, Object> data;
+
+  private MappingData(Map<String, Object> data) {
+    this.data = data;
+  }
+
+  /**
+   * Loads the default mapping data from the classpath resource.
+   *
+   * @return mapping data loaded from the built-in resource file
+   * @throws IllegalStateException if the resource cannot be found
+   */
+  public static MappingData loadDefault() {
+    return loadFromResource(RESOURCE_NAME);
+  }
+
+  /**
+   * Loads mapping data from a named classpath resource relative to this class.
+   *
+   * @param resourceName the resource file name
+   * @return mapping data loaded from the resource
+   * @throws IllegalStateException if the resource cannot be found
+   */
+  static MappingData loadFromResource(String resourceName) {
+    InputStream stream = MappingData.class.getResourceAsStream(resourceName);
+    if (stream == null) {
+      throw new IllegalStateException("Mapping data resource not found: " + resourceName);
+    }
+    Reader reader = new InputStreamReader(stream, StandardCharsets.UTF_8);
+    return new MappingData(GSON.fromJson(reader, MAP_TYPE));
+  }
+
+  /**
+   * Parses mapping data from a JSON string.
+   *
+   * @param json the JSON string to parse, must not be null or empty
+   * @return mapping data parsed from the JSON
+   * @throws NullPointerException if json is null
+   * @throws IllegalArgumentException if json is empty or not valid JSON
+   */
+  public static MappingData fromJson(String json) {
+    Objects.requireNonNull(json, "json");
+    if (json.isEmpty()) {
+      throw new IllegalArgumentException("json must not be empty");
+    }
+    Map<String, Object> parsed = GSON.fromJson(json, MAP_TYPE);
+    if (parsed == null) {
+      throw new IllegalArgumentException("json must not be empty");
+    }
+    return new MappingData(parsed);
+  }
+
+  /**
+   * Creates mapping data from a programmatic map.
+   *
+   * @param data the mapping data map, must not be null
+   * @return mapping data wrapping the provided map
+   * @throws NullPointerException if data is null
+   */
+  public static MappingData fromMap(Map<String, Object> data) {
+    Objects.requireNonNull(data, "data");
+    Map<String, Object> copy = deepCopy(data);
+    return new MappingData(copy);
+  }
+
+  /**
+   * Creates new mapping data with overrides applied.
+   *
+   * @param overrides the override entries to apply, must not be null
+   * @param mode the override strategy, must not be null
+   * @return new mapping data with overrides applied
+   * @throws NullPointerException if overrides or mode is null
+   * @throws IllegalArgumentException if overrides contain invalid top-level keys, or if {@link
+   *     MappingOverrideMode#REPLACE} mode is used with incomplete overrides
+   */
+  public MappingData withOverrides(Map<String, Object> overrides, MappingOverrideMode mode) {
+    Objects.requireNonNull(overrides, "overrides");
+    Objects.requireNonNull(mode, "mode");
+    validateTopLevelKeys(overrides);
+    if (mode == MappingOverrideMode.REPLACE) {
+      return applyReplace(overrides);
+    }
+    return applyMerge(overrides);
+  }
+
+  /**
+   * Returns the qualifier name for a given command.
+   *
+   * @param command the command string (e.g., "DISPLAY QUEUE")
+   * @return the qualifier name, or null if the command is unknown
+   */
+  public String getQualifierForCommand(String command) {
+    Map<String, Object> commands = getCommandsMap();
+    if (commands == null) {
+      return null;
+    }
+    Object entry = commands.get(command);
+    if (entry instanceof Map) {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> commandMap = (Map<String, Object>) entry;
+      Object qualifier = commandMap.get("qualifier");
+      return qualifier instanceof String ? (String) qualifier : null;
+    }
+    return null;
+  }
+
+  /**
+   * Returns the qualifier data map for the given qualifier.
+   *
+   * @param qualifier the qualifier name (e.g., "queue")
+   * @return the qualifier data map, or null if the qualifier is unknown
+   */
+  @SuppressWarnings("unchecked")
+  Map<String, Object> getQualifierData(String qualifier) {
+    Map<String, Object> qualifiers = getQualifiersMap();
+    if (qualifiers == null) {
+      return null;
+    }
+    Object entry = qualifiers.get(qualifier);
+    return entry instanceof Map ? (Map<String, Object>) entry : null;
+  }
+
+  /**
+   * Returns whether the given qualifier exists in the mapping data.
+   *
+   * @param qualifier the qualifier name to check
+   * @return true if the qualifier exists, false otherwise
+   */
+  boolean hasQualifier(String qualifier) {
+    return getQualifierData(qualifier) != null;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> getCommandsMap() {
+    Object commands = data.get("commands");
+    return commands instanceof Map ? (Map<String, Object>) commands : null;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> getQualifiersMap() {
+    Object qualifiers = data.get("qualifiers");
+    return qualifiers instanceof Map ? (Map<String, Object>) qualifiers : null;
+  }
+
+  private static void validateTopLevelKeys(Map<String, Object> map) {
+    for (String key : map.keySet()) {
+      if (!VALID_TOP_LEVEL_KEYS.contains(key)) {
+        throw new IllegalArgumentException("Invalid top-level key in overrides: " + key);
+      }
+    }
+  }
+
+  private MappingData applyReplace(Map<String, Object> overrides) {
+    Map<String, Object> baseCommands = getCommandsMap();
+    Map<String, Object> baseQualifiers = getQualifiersMap();
+    @SuppressWarnings("unchecked")
+    Map<String, Object> overrideCommands =
+        overrides.get("commands") instanceof Map
+            ? (Map<String, Object>) overrides.get("commands")
+            : null;
+    @SuppressWarnings("unchecked")
+    Map<String, Object> overrideQualifiers =
+        overrides.get("qualifiers") instanceof Map
+            ? (Map<String, Object>) overrides.get("qualifiers")
+            : null;
+
+    if (baseCommands != null
+        && !baseCommands.isEmpty()
+        && (overrideCommands == null
+            || !overrideCommands.keySet().containsAll(baseCommands.keySet()))) {
+      throw new IllegalArgumentException("REPLACE overrides must cover all base command keys");
+    }
+    if (baseQualifiers != null
+        && !baseQualifiers.isEmpty()
+        && (overrideQualifiers == null
+            || !overrideQualifiers.keySet().containsAll(baseQualifiers.keySet()))) {
+      throw new IllegalArgumentException("REPLACE overrides must cover all base qualifier keys");
+    }
+    return new MappingData(deepCopy(overrides));
+  }
+
+  private MappingData applyMerge(Map<String, Object> overrides) {
+    Map<String, Object> merged = deepCopy(data);
+    mergeSection(merged, overrides, "commands");
+    mergeSection(merged, overrides, "qualifiers");
+    return new MappingData(merged);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void mergeSection(
+      Map<String, Object> base, Map<String, Object> overrides, String section) {
+    Object overrideSection = overrides.get(section);
+    if (!(overrideSection instanceof Map)) {
+      return;
+    }
+    Map<String, Object> overrideMap = (Map<String, Object>) overrideSection;
+    Object baseSection = base.get(section);
+    if (!(baseSection instanceof Map)) {
+      base.put(section, deepCopy(overrideMap));
+      return;
+    }
+    Map<String, Object> baseMap = (Map<String, Object>) baseSection;
+    for (Map.Entry<String, Object> entry : overrideMap.entrySet()) {
+      String key = entry.getKey();
+      Object overrideValue = entry.getValue();
+      Object baseValue = baseMap.get(key);
+      if (baseValue instanceof Map && overrideValue instanceof Map) {
+        Map<String, Object> mergedSub = new LinkedHashMap<>((Map<String, Object>) baseValue);
+        mergedSub.putAll((Map<String, Object>) overrideValue);
+        baseMap.put(key, mergedSub);
+      } else {
+        baseMap.put(
+            key,
+            overrideValue instanceof Map
+                ? deepCopy((Map<String, Object>) overrideValue)
+                : overrideValue);
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> deepCopy(Map<String, Object> source) {
+    Map<String, Object> copy = new LinkedHashMap<>();
+    for (Map.Entry<String, Object> entry : source.entrySet()) {
+      Object value = entry.getValue();
+      if (value instanceof Map) {
+        copy.put(entry.getKey(), deepCopy((Map<String, Object>) value));
+      } else {
+        copy.put(entry.getKey(), value);
+      }
+    }
+    return copy;
+  }
+}

--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/mapping/MappingOverrideMode.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/mapping/MappingOverrideMode.java
@@ -1,0 +1,16 @@
+package io.github.wphillipmoore.mq.rest.admin.mapping;
+
+/**
+ * Strategy for applying mapping data overrides.
+ *
+ * <p>Controls how user-provided mapping overrides interact with the built-in mapping data loaded
+ * from the default resource file.
+ */
+public enum MappingOverrideMode {
+
+  /** Sparse overlay — override entries layer on top of built-in data. */
+  MERGE,
+
+  /** Complete replacement — override must cover all base keys. */
+  REPLACE
+}

--- a/src/main/resources/io/github/wphillipmoore/mq/rest/admin/mapping/mapping-data.json
+++ b/src/main/resources/io/github/wphillipmoore/mq/rest/admin/mapping/mapping-data.json
@@ -1,0 +1,43 @@
+{
+  "commands": {
+    "DISPLAY QUEUE": {
+      "qualifier": "queue"
+    }
+  },
+  "qualifiers": {
+    "queue": {
+      "request_key_map": {
+        "max_depth": "MAXDEPTH",
+        "description": "DESCR"
+      },
+      "request_value_map": {
+        "get": {
+          "enabled": "ENABLED",
+          "disabled": "DISABLED"
+        }
+      },
+      "request_key_value_map": {
+        "purge": {
+          "yes": {
+            "key": "PURGE",
+            "value": "YES"
+          },
+          "no": {
+            "key": "PURGE",
+            "value": "NO"
+          }
+        }
+      },
+      "response_key_map": {
+        "MAXDEPTH": "max_depth",
+        "DESCR": "description"
+      },
+      "response_value_map": {
+        "GET": {
+          "ENABLED": "enabled",
+          "DISABLED": "disabled"
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/mapping/AttributeMapperTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/mapping/AttributeMapperTest.java
@@ -1,0 +1,533 @@
+package io.github.wphillipmoore.mq.rest.admin.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AttributeMapperTest {
+
+  private static final String TEST_JSON =
+      """
+      {
+        "commands": {
+          "DISPLAY QUEUE": {"qualifier": "queue"}
+        },
+        "qualifiers": {
+          "queue": {
+            "request_key_map": {
+              "max_depth": "MAXDEPTH",
+              "description": "DESCR",
+              "get": "GET"
+            },
+            "request_value_map": {
+              "get": {
+                "enabled": "ENABLED",
+                "disabled": "DISABLED"
+              }
+            },
+            "request_key_value_map": {
+              "purge": {
+                "yes": {"key": "PURGE", "value": "YES"},
+                "no": {"key": "PURGE", "value": "NO"}
+              }
+            },
+            "response_key_map": {
+              "MAXDEPTH": "max_depth",
+              "DESCR": "description",
+              "GET": "get"
+            },
+            "response_value_map": {
+              "GET": {
+                "ENABLED": "enabled",
+                "DISABLED": "disabled"
+              }
+            }
+          }
+        }
+      }
+      """;
+
+  private final AttributeMapper mapper = new AttributeMapper(MappingData.fromJson(TEST_JSON));
+
+  @Test
+  void requestKeyMapping() {
+    Map<String, Object> input = Map.of("max_depth", 5000);
+
+    Map<String, Object> result = mapper.mapRequestAttributes("queue", input, false);
+
+    assertThat(result).containsEntry("MAXDEPTH", 5000);
+  }
+
+  @Test
+  void requestValueMapping() {
+    Map<String, Object> input = Map.of("get", "enabled");
+
+    Map<String, Object> result = mapper.mapRequestAttributes("queue", input, false);
+
+    assertThat(result).containsEntry("GET", "ENABLED");
+  }
+
+  @Test
+  void requestKeyValueMapping() {
+    Map<String, Object> input = Map.of("purge", "yes");
+
+    Map<String, Object> result = mapper.mapRequestAttributes("queue", input, false);
+
+    assertThat(result).containsEntry("PURGE", "YES");
+    assertThat(result).doesNotContainKey("purge");
+  }
+
+  @Test
+  void requestKeyValueUnknownValueRecordsIssue() {
+    Map<String, Object> input = Map.of("purge", "maybe");
+
+    Map<String, Object> result = mapper.mapRequestAttributes("queue", input, false);
+
+    assertThat(result).containsEntry("purge", "maybe");
+  }
+
+  @Test
+  void requestKeyValueUnknownValueStrictThrows() {
+    Map<String, Object> input = Map.of("purge", "maybe");
+
+    assertThatThrownBy(() -> mapper.mapRequestAttributes("queue", input, true))
+        .isInstanceOf(MappingException.class)
+        .satisfies(
+            ex -> {
+              MappingException me = (MappingException) ex;
+              assertThat(me.getIssues()).hasSize(1);
+              assertThat(me.getIssues().get(0).reason()).isEqualTo(MappingReason.UNKNOWN_VALUE);
+              assertThat(me.getIssues().get(0).attributeName()).isEqualTo("purge");
+            });
+  }
+
+  @Test
+  void responseKeyMapping() {
+    Map<String, Object> input = Map.of("MAXDEPTH", 5000);
+
+    Map<String, Object> result = mapper.mapResponseAttributes("queue", input, false);
+
+    assertThat(result).containsEntry("max_depth", 5000);
+  }
+
+  @Test
+  void responseValueMapping() {
+    Map<String, Object> input = Map.of("GET", "ENABLED");
+
+    Map<String, Object> result = mapper.mapResponseAttributes("queue", input, false);
+
+    assertThat(result).containsEntry("get", "enabled");
+  }
+
+  @Test
+  void responseDoesNotUseKeyValueMap() {
+    Map<String, Object> input = new LinkedHashMap<>();
+    input.put("purge", "yes");
+
+    Map<String, Object> result = mapper.mapResponseAttributes("queue", input, false);
+
+    // "purge" is not in response_key_map, so it passes through as UNKNOWN_KEY
+    assertThat(result).containsEntry("purge", "yes");
+    assertThat(result).doesNotContainKey("PURGE");
+  }
+
+  @Test
+  void unknownKeyStrictThrows() {
+    Map<String, Object> input = Map.of("unknown_attr", "val");
+
+    assertThatThrownBy(() -> mapper.mapRequestAttributes("queue", input, true))
+        .isInstanceOf(MappingException.class)
+        .satisfies(
+            ex -> {
+              MappingException me = (MappingException) ex;
+              assertThat(me.getIssues()).hasSize(1);
+              assertThat(me.getIssues().get(0).reason()).isEqualTo(MappingReason.UNKNOWN_KEY);
+              assertThat(me.getIssues().get(0).attributeName()).isEqualTo("unknown_attr");
+            });
+  }
+
+  @Test
+  void unknownKeyPermissivePassesThrough() {
+    Map<String, Object> input = new LinkedHashMap<>();
+    input.put("unknown_attr", "val");
+    input.put("max_depth", 5000);
+
+    Map<String, Object> result = mapper.mapRequestAttributes("queue", input, false);
+
+    assertThat(result).containsEntry("unknown_attr", "val");
+    assertThat(result).containsEntry("MAXDEPTH", 5000);
+  }
+
+  @Test
+  void unknownValueStrictThrows() {
+    Map<String, Object> input = Map.of("get", "unknown_state");
+
+    assertThatThrownBy(() -> mapper.mapRequestAttributes("queue", input, true))
+        .isInstanceOf(MappingException.class)
+        .satisfies(
+            ex -> {
+              MappingException me = (MappingException) ex;
+              assertThat(me.getIssues()).hasSize(1);
+              assertThat(me.getIssues().get(0).reason()).isEqualTo(MappingReason.UNKNOWN_VALUE);
+              assertThat(me.getIssues().get(0).attributeValue()).isEqualTo("unknown_state");
+            });
+  }
+
+  @Test
+  void unknownValuePermissivePassesThrough() {
+    Map<String, Object> input = Map.of("get", "unknown_state");
+
+    Map<String, Object> result = mapper.mapRequestAttributes("queue", input, false);
+
+    assertThat(result).containsEntry("GET", "unknown_state");
+  }
+
+  @Test
+  void unknownQualifierStrictThrows() {
+    Map<String, Object> input = Map.of("attr", "val");
+
+    assertThatThrownBy(() -> mapper.mapRequestAttributes("nonexistent", input, true))
+        .isInstanceOf(MappingException.class)
+        .satisfies(
+            ex -> {
+              MappingException me = (MappingException) ex;
+              assertThat(me.getIssues()).hasSize(1);
+              assertThat(me.getIssues().get(0).reason()).isEqualTo(MappingReason.UNKNOWN_QUALIFIER);
+            });
+  }
+
+  @Test
+  void unknownQualifierPermissiveReturnsInputUnchanged() {
+    Map<String, Object> input = Map.of("attr", "val");
+
+    Map<String, Object> result = mapper.mapRequestAttributes("nonexistent", input, false);
+
+    assertThat(result).containsEntry("attr", "val");
+  }
+
+  @Test
+  void multipleIssuesAllCollected() {
+    Map<String, Object> input = new LinkedHashMap<>();
+    input.put("unknown1", "val1");
+    input.put("unknown2", "val2");
+
+    assertThatThrownBy(() -> mapper.mapRequestAttributes("queue", input, true))
+        .isInstanceOf(MappingException.class)
+        .satisfies(
+            ex -> {
+              MappingException me = (MappingException) ex;
+              assertThat(me.getIssues()).hasSize(2);
+            });
+  }
+
+  @Test
+  void listValueMappingMapsEachElement() {
+    Map<String, Object> input = Map.of("get", List.of("enabled", "disabled"));
+
+    Map<String, Object> result = mapper.mapRequestAttributes("queue", input, false);
+
+    assertThat(result).containsEntry("GET", List.of("ENABLED", "DISABLED"));
+  }
+
+  @Test
+  void listValueWithUnknownElementRecordsIssue() {
+    Map<String, Object> input = Map.of("get", List.of("enabled", "unknown"));
+
+    assertThatThrownBy(() -> mapper.mapRequestAttributes("queue", input, true))
+        .isInstanceOf(MappingException.class)
+        .satisfies(
+            ex -> {
+              MappingException me = (MappingException) ex;
+              assertThat(me.getIssues()).hasSize(1);
+              assertThat(me.getIssues().get(0).reason()).isEqualTo(MappingReason.UNKNOWN_VALUE);
+              assertThat(me.getIssues().get(0).attributeValue()).isEqualTo("unknown");
+            });
+  }
+
+  @Test
+  void nonStringValuePassesThroughUnchanged() {
+    Map<String, Object> input = Map.of("get", 42);
+
+    Map<String, Object> result = mapper.mapRequestAttributes("queue", input, false);
+
+    assertThat(result).containsEntry("GET", 42);
+  }
+
+  @Test
+  void mapResponseListMapsEachObjectWithIndex() {
+    Map<String, Object> obj1 = Map.of("MAXDEPTH", 5000);
+    Map<String, Object> obj2 = Map.of("MAXDEPTH", 10000);
+
+    List<Map<String, Object>> result = mapper.mapResponseList("queue", List.of(obj1, obj2), false);
+
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0)).containsEntry("max_depth", 5000);
+    assertThat(result.get(1)).containsEntry("max_depth", 10000);
+  }
+
+  @Test
+  void mapResponseListStrictThrowsWithAllIssues() {
+    Map<String, Object> obj1 = Map.of("UNKNOWN1", "val");
+    Map<String, Object> obj2 = Map.of("UNKNOWN2", "val");
+
+    assertThatThrownBy(() -> mapper.mapResponseList("queue", List.of(obj1, obj2), true))
+        .isInstanceOf(MappingException.class)
+        .satisfies(
+            ex -> {
+              MappingException me = (MappingException) ex;
+              assertThat(me.getIssues()).hasSize(2);
+              assertThat(me.getIssues().get(0).objectIndex()).isEqualTo(0);
+              assertThat(me.getIssues().get(1).objectIndex()).isEqualTo(1);
+            });
+  }
+
+  @Test
+  void emptyAttributesReturnsEmptyMap() {
+    Map<String, Object> result = mapper.mapRequestAttributes("queue", Map.of(), false);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void defaultConstructorLoadsDefaultMappingData() {
+    assertThatCode(AttributeMapper::new).doesNotThrowAnyException();
+  }
+
+  @Test
+  void requestKeyValueMappingWithNonStringValueRecordsIssue() {
+    Map<String, Object> input = Map.of("purge", 123);
+
+    Map<String, Object> result = mapper.mapRequestAttributes("queue", input, false);
+
+    assertThat(result).containsEntry("purge", 123);
+  }
+
+  @Test
+  void listValueWithNonStringElementPassesThrough() {
+    Map<String, Object> input = Map.of("get", List.of("enabled", 42, "disabled"));
+
+    Map<String, Object> result = mapper.mapRequestAttributes("queue", input, false);
+
+    @SuppressWarnings("unchecked")
+    List<Object> mapped = (List<Object>) result.get("GET");
+    assertThat(mapped).containsExactly("ENABLED", 42, "DISABLED");
+  }
+
+  @Test
+  void responseListPermissiveWithIssuesReturnsResults() {
+    Map<String, Object> obj = Map.of("UNKNOWN", "val");
+
+    List<Map<String, Object>> result = mapper.mapResponseList("queue", List.of(obj), false);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0)).containsEntry("UNKNOWN", "val");
+  }
+
+  @Test
+  void unknownQualifierPermissiveResponseList() {
+    Map<String, Object> obj = Map.of("key", "val");
+
+    List<Map<String, Object>> result = mapper.mapResponseList("nonexistent", List.of(obj), false);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0)).containsEntry("key", "val");
+  }
+
+  @Test
+  void unknownQualifierStrictResponseListThrows() {
+    Map<String, Object> obj = Map.of("key", "val");
+
+    assertThatThrownBy(() -> mapper.mapResponseList("nonexistent", List.of(obj), true))
+        .isInstanceOf(MappingException.class)
+        .satisfies(
+            ex -> {
+              MappingException me = (MappingException) ex;
+              assertThat(me.getIssues()).hasSize(1);
+              assertThat(me.getIssues().get(0).reason()).isEqualTo(MappingReason.UNKNOWN_QUALIFIER);
+              assertThat(me.getIssues().get(0).objectIndex()).isEqualTo(0);
+            });
+  }
+
+  @Test
+  void requestKeyValueMappingBothDirections() {
+    Map<String, Object> input = Map.of("purge", "no");
+
+    Map<String, Object> result = mapper.mapRequestAttributes("queue", input, false);
+
+    assertThat(result).containsEntry("PURGE", "NO");
+  }
+
+  @Test
+  void multipleAttributesMappedCorrectly() {
+    Map<String, Object> input = new LinkedHashMap<>();
+    input.put("max_depth", 5000);
+    input.put("description", "test queue");
+
+    Map<String, Object> result = mapper.mapRequestAttributes("queue", input, false);
+
+    assertThat(result).containsEntry("MAXDEPTH", 5000);
+    assertThat(result).containsEntry("DESCR", "test queue");
+  }
+
+  @Test
+  void nullDataThrowsNullPointerException() {
+    assertThatThrownBy(() -> new AttributeMapper(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("data");
+  }
+
+  @Test
+  void responseUnknownKeyStrictThrows() {
+    Map<String, Object> input = Map.of("UNKNOWN", "val");
+
+    assertThatThrownBy(() -> mapper.mapResponseAttributes("queue", input, true))
+        .isInstanceOf(MappingException.class)
+        .satisfies(
+            ex -> {
+              MappingException me = (MappingException) ex;
+              assertThat(me.getIssues()).hasSize(1);
+              assertThat(me.getIssues().get(0).reason()).isEqualTo(MappingReason.UNKNOWN_KEY);
+              assertThat(me.getIssues().get(0).direction()).isEqualTo(MappingDirection.RESPONSE);
+            });
+  }
+
+  @Test
+  void qualifierWithNoKeyMapsPassesThrough() {
+    String json =
+        """
+        {
+          "commands": {},
+          "qualifiers": {
+            "minimal": {}
+          }
+        }
+        """;
+    AttributeMapper minMapper = new AttributeMapper(MappingData.fromJson(json));
+
+    Map<String, Object> input = Map.of("attr", "val");
+
+    Map<String, Object> result = minMapper.mapRequestAttributes("minimal", input, false);
+
+    assertThat(result).containsEntry("attr", "val");
+  }
+
+  @Test
+  void requestKeyValueWithNonMapEntryRecordsIssue() {
+    String json =
+        """
+        {
+          "commands": {},
+          "qualifiers": {
+            "q": {
+              "request_key_map": {},
+              "request_key_value_map": {
+                "attr": "not_a_map"
+              }
+            }
+          }
+        }
+        """;
+    AttributeMapper testMapper = new AttributeMapper(MappingData.fromJson(json));
+
+    Map<String, Object> result = testMapper.mapRequestAttributes("q", Map.of("attr", "val"), false);
+
+    assertThat(result).containsEntry("attr", "val");
+  }
+
+  @Test
+  void valueMapWithNonMapEntryPassesThrough() {
+    String json =
+        """
+        {
+          "commands": {},
+          "qualifiers": {
+            "q": {
+              "request_key_map": {"attr": "ATTR"},
+              "request_value_map": {
+                "attr": "not_a_map"
+              }
+            }
+          }
+        }
+        """;
+    AttributeMapper testMapper = new AttributeMapper(MappingData.fromJson(json));
+
+    Map<String, Object> result = testMapper.mapRequestAttributes("q", Map.of("attr", "val"), false);
+
+    assertThat(result).containsEntry("ATTR", "val");
+  }
+
+  @Test
+  void requestKeyValueWithNonMapTargetRecordsIssue() {
+    String json =
+        """
+        {
+          "commands": {},
+          "qualifiers": {
+            "q": {
+              "request_key_map": {},
+              "request_key_value_map": {
+                "attr": {
+                  "val": "not_a_map_target"
+                }
+              }
+            }
+          }
+        }
+        """;
+    AttributeMapper testMapper = new AttributeMapper(MappingData.fromJson(json));
+
+    Map<String, Object> result = testMapper.mapRequestAttributes("q", Map.of("attr", "val"), false);
+
+    assertThat(result).containsEntry("attr", "val");
+  }
+
+  @Test
+  void mapResponseListStrictWithUnknownQualifierThrows() {
+    Map<String, Object> obj = Map.of("key", "val");
+
+    assertThatThrownBy(
+            () -> mapper.mapResponseList("nonexistent", List.of(obj, Map.of("k", "v")), true))
+        .isInstanceOf(MappingException.class)
+        .satisfies(
+            ex -> {
+              MappingException me = (MappingException) ex;
+              assertThat(me.getIssues()).hasSize(2);
+              assertThat(me.getIssues().get(0).objectIndex()).isEqualTo(0);
+              assertThat(me.getIssues().get(1).objectIndex()).isEqualTo(1);
+            });
+  }
+
+  @Test
+  void requestStrictWithNoIssuesSucceeds() {
+    Map<String, Object> input = Map.of("max_depth", 5000);
+
+    Map<String, Object> result = mapper.mapRequestAttributes("queue", input, true);
+
+    assertThat(result).containsEntry("MAXDEPTH", 5000);
+  }
+
+  @Test
+  void responseStrictWithNoIssuesSucceeds() {
+    Map<String, Object> input = Map.of("MAXDEPTH", 5000);
+
+    Map<String, Object> result = mapper.mapResponseAttributes("queue", input, true);
+
+    assertThat(result).containsEntry("max_depth", 5000);
+  }
+
+  @Test
+  void mapResponseListStrictWithNoIssuesSucceeds() {
+    Map<String, Object> obj = Map.of("MAXDEPTH", 5000);
+
+    List<Map<String, Object>> result = mapper.mapResponseList("queue", List.of(obj), true);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0)).containsEntry("max_depth", 5000);
+  }
+}

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/mapping/MappingDataTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/mapping/MappingDataTest.java
@@ -1,0 +1,365 @@
+package io.github.wphillipmoore.mq.rest.admin.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MappingDataTest {
+
+  private static final String VALID_JSON =
+      """
+      {
+        "commands": {
+          "DISPLAY QUEUE": {"qualifier": "queue"}
+        },
+        "qualifiers": {
+          "queue": {
+            "request_key_map": {"max_depth": "MAXDEPTH"},
+            "response_key_map": {"MAXDEPTH": "max_depth"}
+          }
+        }
+      }
+      """;
+
+  @Test
+  void loadDefaultReturnsNonNull() {
+    MappingData data = MappingData.loadDefault();
+
+    assertThat(data).isNotNull();
+  }
+
+  @Test
+  void loadDefaultContainsExpectedCommand() {
+    MappingData data = MappingData.loadDefault();
+
+    assertThat(data.getQualifierForCommand("DISPLAY QUEUE")).isEqualTo("queue");
+  }
+
+  @Test
+  void fromJsonParsesValidJson() {
+    MappingData data = MappingData.fromJson(VALID_JSON);
+
+    assertThat(data.getQualifierForCommand("DISPLAY QUEUE")).isEqualTo("queue");
+  }
+
+  @Test
+  void fromMapCreatesFromProgrammaticMap() {
+    Map<String, Object> commands = new LinkedHashMap<>();
+    commands.put("ALTER QUEUE", Map.of("qualifier", "queue"));
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("commands", commands);
+    map.put("qualifiers", Map.of());
+
+    MappingData data = MappingData.fromMap(map);
+
+    assertThat(data.getQualifierForCommand("ALTER QUEUE")).isEqualTo("queue");
+  }
+
+  @Test
+  void getQualifierForCommandReturnsNullForUnknownCommand() {
+    MappingData data = MappingData.fromJson(VALID_JSON);
+
+    assertThat(data.getQualifierForCommand("UNKNOWN COMMAND")).isNull();
+  }
+
+  @Test
+  void hasQualifierReturnsTrueForKnownQualifier() {
+    MappingData data = MappingData.fromJson(VALID_JSON);
+
+    assertThat(data.hasQualifier("queue")).isTrue();
+  }
+
+  @Test
+  void hasQualifierReturnsFalseForUnknownQualifier() {
+    MappingData data = MappingData.fromJson(VALID_JSON);
+
+    assertThat(data.hasQualifier("channel")).isFalse();
+  }
+
+  @Test
+  void getQualifierDataReturnsDataForKnownQualifier() {
+    MappingData data = MappingData.fromJson(VALID_JSON);
+
+    Map<String, Object> qualifierData = data.getQualifierData("queue");
+
+    assertThat(qualifierData).isNotNull();
+    assertThat(qualifierData).containsKey("request_key_map");
+  }
+
+  @Test
+  void getQualifierDataReturnsNullForUnknownQualifier() {
+    MappingData data = MappingData.fromJson(VALID_JSON);
+
+    assertThat(data.getQualifierData("channel")).isNull();
+  }
+
+  @Test
+  void withOverridesMergeMergesNewEntries() {
+    MappingData base = MappingData.fromJson(VALID_JSON);
+    Map<String, Object> overrides = new LinkedHashMap<>();
+    overrides.put("commands", Map.of("DISPLAY CHANNEL", Map.of("qualifier", "channel")));
+
+    MappingData merged = base.withOverrides(overrides, MappingOverrideMode.MERGE);
+
+    assertThat(merged.getQualifierForCommand("DISPLAY QUEUE")).isEqualTo("queue");
+    assertThat(merged.getQualifierForCommand("DISPLAY CHANNEL")).isEqualTo("channel");
+  }
+
+  @Test
+  void withOverridesMergeOverridesExistingEntries() {
+    MappingData base = MappingData.fromJson(VALID_JSON);
+    Map<String, Object> overrides = new LinkedHashMap<>();
+    overrides.put("commands", Map.of("DISPLAY QUEUE", Map.of("qualifier", "local_queue")));
+
+    MappingData merged = base.withOverrides(overrides, MappingOverrideMode.MERGE);
+
+    assertThat(merged.getQualifierForCommand("DISPLAY QUEUE")).isEqualTo("local_queue");
+  }
+
+  @Test
+  void withOverridesReplaceReplacesDataEntirely() {
+    String replaceJson =
+        """
+        {
+          "commands": {
+            "DISPLAY QUEUE": {"qualifier": "queue"},
+            "ALTER QUEUE": {"qualifier": "queue"}
+          },
+          "qualifiers": {
+            "queue": {
+              "request_key_map": {"depth": "CURDEPTH"},
+              "response_key_map": {"CURDEPTH": "depth"}
+            }
+          }
+        }
+        """;
+    MappingData base = MappingData.fromJson(VALID_JSON);
+    Map<String, Object> overrides = new LinkedHashMap<>();
+    overrides.put(
+        "commands",
+        Map.of(
+            "DISPLAY QUEUE",
+            Map.of("qualifier", "queue"),
+            "ALTER QUEUE",
+            Map.of("qualifier", "queue")));
+    Map<String, Object> qualifierData = new LinkedHashMap<>();
+    qualifierData.put("queue", Map.of("request_key_map", Map.of("depth", "CURDEPTH")));
+    overrides.put("qualifiers", qualifierData);
+
+    MappingData replaced = base.withOverrides(overrides, MappingOverrideMode.REPLACE);
+
+    assertThat(replaced.getQualifierForCommand("DISPLAY QUEUE")).isEqualTo("queue");
+    assertThat(replaced.getQualifierForCommand("ALTER QUEUE")).isEqualTo("queue");
+  }
+
+  @Test
+  void withOverridesReplaceThrowsForIncompletCommands() {
+    MappingData base = MappingData.fromJson(VALID_JSON);
+    Map<String, Object> overrides = new LinkedHashMap<>();
+    overrides.put("commands", Map.of());
+    overrides.put("qualifiers", Map.of("queue", Map.of()));
+
+    assertThatThrownBy(() -> base.withOverrides(overrides, MappingOverrideMode.REPLACE))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("command");
+  }
+
+  @Test
+  void withOverridesReplaceThrowsForIncompleteQualifiers() {
+    MappingData base = MappingData.fromJson(VALID_JSON);
+    Map<String, Object> overrides = new LinkedHashMap<>();
+    overrides.put("commands", Map.of("DISPLAY QUEUE", Map.of("qualifier", "queue")));
+    overrides.put("qualifiers", Map.of());
+
+    assertThatThrownBy(() -> base.withOverrides(overrides, MappingOverrideMode.REPLACE))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("qualifier");
+  }
+
+  @Test
+  void withOverridesInvalidTopLevelKeyThrowsIllegalArgumentException() {
+    MappingData base = MappingData.fromJson(VALID_JSON);
+    Map<String, Object> overrides = Map.of("invalid_key", Map.of());
+
+    assertThatThrownBy(() -> base.withOverrides(overrides, MappingOverrideMode.MERGE))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("invalid_key");
+  }
+
+  @Test
+  void fromJsonNullThrowsNullPointerException() {
+    assertThatThrownBy(() -> MappingData.fromJson(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("json");
+  }
+
+  @Test
+  void fromJsonEmptyStringThrowsIllegalArgumentException() {
+    assertThatThrownBy(() -> MappingData.fromJson(""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("empty");
+  }
+
+  @Test
+  void fromMapNullThrowsNullPointerException() {
+    assertThatThrownBy(() -> MappingData.fromMap(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("data");
+  }
+
+  @Test
+  void withOverridesNullOverridesThrowsNullPointerException() {
+    MappingData data = MappingData.fromJson(VALID_JSON);
+
+    assertThatThrownBy(() -> data.withOverrides(null, MappingOverrideMode.MERGE))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("overrides");
+  }
+
+  @Test
+  void withOverridesNullModeThrowsNullPointerException() {
+    MappingData data = MappingData.fromJson(VALID_JSON);
+
+    assertThatThrownBy(() -> data.withOverrides(Map.of(), null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("mode");
+  }
+
+  @Test
+  void fromMapDoesNotMutateOriginal() {
+    Map<String, Object> commands = new LinkedHashMap<>();
+    commands.put("CMD", Map.of("qualifier", "q"));
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("commands", commands);
+    map.put("qualifiers", Map.of());
+
+    MappingData data = MappingData.fromMap(map);
+    commands.put("NEW_CMD", Map.of("qualifier", "q2"));
+
+    assertThat(data.getQualifierForCommand("NEW_CMD")).isNull();
+  }
+
+  @Test
+  void getQualifierForCommandReturnsNullWhenNoCommandsSection() {
+    MappingData data = MappingData.fromMap(Map.of());
+
+    assertThat(data.getQualifierForCommand("DISPLAY QUEUE")).isNull();
+  }
+
+  @Test
+  void hasQualifierReturnsFalseWhenNoQualifiersSection() {
+    MappingData data = MappingData.fromMap(Map.of());
+
+    assertThat(data.hasQualifier("queue")).isFalse();
+  }
+
+  @Test
+  void loadFromResourceThrowsForMissingResource() {
+    assertThatThrownBy(() -> MappingData.loadFromResource("nonexistent.json"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("nonexistent.json");
+  }
+
+  @Test
+  void fromJsonNullLiteralThrowsIllegalArgumentException() {
+    assertThatThrownBy(() -> MappingData.fromJson("null"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("empty");
+  }
+
+  @Test
+  void withOverridesMergeWhenBaseSectionMissing() {
+    MappingData base = MappingData.fromMap(Map.of());
+    Map<String, Object> overrides = new LinkedHashMap<>();
+    overrides.put("commands", Map.of("DISPLAY QUEUE", Map.of("qualifier", "queue")));
+
+    MappingData merged = base.withOverrides(overrides, MappingOverrideMode.MERGE);
+
+    assertThat(merged.getQualifierForCommand("DISPLAY QUEUE")).isEqualTo("queue");
+  }
+
+  @Test
+  void withOverridesMergeWithScalarOverrideValue() {
+    MappingData base = MappingData.fromJson(VALID_JSON);
+    Map<String, Object> overrides = new LinkedHashMap<>();
+    Map<String, Object> commandOverrides = new LinkedHashMap<>();
+    commandOverrides.put("DISPLAY QUEUE", "scalar_value");
+    overrides.put("commands", commandOverrides);
+
+    MappingData merged = base.withOverrides(overrides, MappingOverrideMode.MERGE);
+
+    // The scalar replaces the Map entry
+    assertThat(merged.getQualifierForCommand("DISPLAY QUEUE")).isNull();
+  }
+
+  @Test
+  void withOverridesReplaceWhenOverrideCommandsNotMap() {
+    MappingData base = MappingData.fromJson(VALID_JSON);
+    Map<String, Object> overrides = new LinkedHashMap<>();
+    overrides.put("commands", "not_a_map");
+    overrides.put("qualifiers", Map.of("queue", Map.of()));
+
+    assertThatThrownBy(() -> base.withOverrides(overrides, MappingOverrideMode.REPLACE))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("command");
+  }
+
+  @Test
+  void withOverridesReplaceWhenOverrideQualifiersNotMap() {
+    MappingData base = MappingData.fromJson(VALID_JSON);
+    Map<String, Object> overrides = new LinkedHashMap<>();
+    overrides.put("commands", Map.of("DISPLAY QUEUE", Map.of("qualifier", "queue")));
+    overrides.put("qualifiers", "not_a_map");
+
+    assertThatThrownBy(() -> base.withOverrides(overrides, MappingOverrideMode.REPLACE))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("qualifier");
+  }
+
+  @Test
+  void getQualifierForCommandReturnsNullWhenCommandEntryNotMap() {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("commands", Map.of("BAD_CMD", "not_a_map"));
+    MappingData data = MappingData.fromMap(map);
+
+    assertThat(data.getQualifierForCommand("BAD_CMD")).isNull();
+  }
+
+  @Test
+  void getQualifierForCommandReturnsNullWhenQualifierFieldNotString() {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("commands", Map.of("CMD", Map.of("qualifier", 123)));
+    MappingData data = MappingData.fromMap(map);
+
+    assertThat(data.getQualifierForCommand("CMD")).isNull();
+  }
+
+  @Test
+  void withOverridesReplaceSucceedsWhenBaseHasNoCommands() {
+    MappingData base = MappingData.fromMap(Map.of());
+    Map<String, Object> overrides = new LinkedHashMap<>();
+    overrides.put("commands", Map.of("NEW", Map.of("qualifier", "q")));
+
+    MappingData replaced = base.withOverrides(overrides, MappingOverrideMode.REPLACE);
+
+    assertThat(replaced.getQualifierForCommand("NEW")).isEqualTo("q");
+  }
+
+  @Test
+  void withOverridesReplaceSucceedsWhenBaseHasEmptyCommandsAndQualifiers() {
+    Map<String, Object> baseMap = new LinkedHashMap<>();
+    baseMap.put("commands", new LinkedHashMap<>());
+    baseMap.put("qualifiers", new LinkedHashMap<>());
+    MappingData base = MappingData.fromMap(baseMap);
+    Map<String, Object> overrides = new LinkedHashMap<>();
+    overrides.put("commands", Map.of("NEW", Map.of("qualifier", "q")));
+    overrides.put("qualifiers", Map.of("q", Map.of()));
+
+    MappingData replaced = base.withOverrides(overrides, MappingOverrideMode.REPLACE);
+
+    assertThat(replaced.getQualifierForCommand("NEW")).isEqualTo("q");
+  }
+}

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/mapping/MappingOverrideModeTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/mapping/MappingOverrideModeTest.java
@@ -1,0 +1,23 @@
+package io.github.wphillipmoore.mq.rest.admin.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class MappingOverrideModeTest {
+
+  @Test
+  void enumHasExactlyTwoValues() {
+    assertThat(MappingOverrideMode.values()).hasSize(2);
+  }
+
+  @Test
+  void mergeValueOfRoundTrips() {
+    assertThat(MappingOverrideMode.valueOf("MERGE")).isEqualTo(MappingOverrideMode.MERGE);
+  }
+
+  @Test
+  void replaceValueOfRoundTrips() {
+    assertThat(MappingOverrideMode.valueOf("REPLACE")).isEqualTo(MappingOverrideMode.REPLACE);
+  }
+}


### PR DESCRIPTION
## Summary

- Implement the 3-layer attribute mapping pipeline (step 5 of tier 3 implementation)
- Add `MappingOverrideMode` enum with MERGE and REPLACE strategies
- Add `MappingData` class for JSON loading, factory methods, and override merging
- Add `AttributeMapper` class with key map, value map, and key-value map pipeline layers
- Include minimal `mapping-data.json` resource skeleton (full production data is a follow-up)
- Add 75 new tests (165 total), achieving 100% line and branch coverage

## Test plan

- [x] `./mvnw verify` passes full pipeline (Spotless, Checkstyle, Surefire, JaCoCo 100%, SpotBugs, PMD)
- [x] All 3 pipeline layers tested in both request and response directions
- [x] Strict and permissive modes tested for all issue types (UNKNOWN_KEY, UNKNOWN_VALUE, UNKNOWN_QUALIFIER)
- [x] MappingData override merging tested for both MERGE and REPLACE modes
- [x] Edge cases covered: empty attributes, non-string values, list values, malformed mapping data

🤖 Generated with [Claude Code](https://claude.com/claude-code)