### PR TITLE
feat: implement MqRestSession core

### DIFF
--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/MqRestSession.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/MqRestSession.java
@@ -1,0 +1,700 @@
+package io.github.wphillipmoore.mq.rest.admin;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import io.github.wphillipmoore.mq.rest.admin.auth.BasicAuth;
+import io.github.wphillipmoore.mq.rest.admin.auth.Credentials;
+import io.github.wphillipmoore.mq.rest.admin.auth.LtpaAuth;
+import io.github.wphillipmoore.mq.rest.admin.exception.MqRestAuthException;
+import io.github.wphillipmoore.mq.rest.admin.exception.MqRestCommandException;
+import io.github.wphillipmoore.mq.rest.admin.exception.MqRestResponseException;
+import io.github.wphillipmoore.mq.rest.admin.mapping.AttributeMapper;
+import io.github.wphillipmoore.mq.rest.admin.mapping.MappingData;
+import io.github.wphillipmoore.mq.rest.admin.mapping.MappingException;
+import io.github.wphillipmoore.mq.rest.admin.mapping.MappingIssue;
+import io.github.wphillipmoore.mq.rest.admin.mapping.MappingOverrideMode;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+/**
+ * Central session class for the MQ REST administrative API.
+ *
+ * <p>Manages URL/header building, MQSC command dispatch, response parsing, error detection, and
+ * attribute mapping integration. Mirrors pymqrest's {@code MQRESTSession}.
+ *
+ * <p>Instances are created via the {@link Builder}:
+ *
+ * <pre>{@code
+ * MqRestSession session = new MqRestSession.Builder(
+ *         "https://host:9443/ibmmq/rest/v2", "QM1",
+ *         new BasicAuth("user", "pass"))
+ *     .transport(mockTransport)
+ *     .build();
+ * }</pre>
+ */
+public final class MqRestSession {
+
+  static final String DEFAULT_CSRF_TOKEN = "local";
+  static final String LTPA_COOKIE_NAME = "LtpaToken2";
+  static final String LTPA_LOGIN_PATH = "/login";
+  static final String GATEWAY_HEADER = "ibm-mq-rest-gateway-qmgr";
+
+  private static final Map<String, String> DEFAULT_MAPPING_QUALIFIERS =
+      Map.ofEntries(
+          Map.entry("QUEUE", "queue"),
+          Map.entry("QLOCAL", "queue"),
+          Map.entry("QREMOTE", "queue"),
+          Map.entry("QALIAS", "queue"),
+          Map.entry("QMODEL", "queue"),
+          Map.entry("QMSTATUS", "qmstatus"),
+          Map.entry("QSTATUS", "qstatus"),
+          Map.entry("CHANNEL", "channel"),
+          Map.entry("QMGR", "qmgr"));
+
+  private static final Gson GSON = new Gson();
+  private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
+
+  private final String restBaseUrl;
+  private final String qmgrName;
+  private final Credentials credentials;
+  private final MqRestTransport transport;
+  private final String gatewayQmgr;
+  private final boolean verifyTls;
+  private final Duration timeout;
+  private final boolean mapAttributes;
+  private final boolean mappingStrict;
+  private final String csrfToken;
+  private final MappingData mappingData;
+  private final AttributeMapper attributeMapper;
+
+  private String ltpaToken;
+  private Integer lastHttpStatus;
+  private String lastResponseText;
+  private Map<String, Object> lastResponsePayload;
+  private Map<String, Object> lastCommandPayload;
+
+  private MqRestSession(Builder builder) {
+    this.restBaseUrl = stripTrailingSlashes(builder.restBaseUrl);
+    this.qmgrName = builder.qmgrName;
+    this.credentials = builder.credentials;
+    this.transport = builder.transport;
+    this.gatewayQmgr = builder.gatewayQmgr;
+    this.verifyTls = builder.verifyTls;
+    this.timeout = builder.timeout;
+    this.mapAttributes = builder.mapAttributes;
+    this.mappingStrict = builder.mappingStrict;
+    this.csrfToken = builder.csrfToken;
+
+    MappingData data = MappingData.loadDefault();
+    if (builder.mappingOverrides != null) {
+      data = data.withOverrides(builder.mappingOverrides, builder.mappingOverridesMode);
+    }
+    this.mappingData = data;
+    this.attributeMapper = new AttributeMapper(this.mappingData);
+
+    if (credentials instanceof LtpaAuth ltpaAuth) {
+      performLtpaLogin(ltpaAuth);
+    }
+  }
+
+  /** Returns the queue manager name. */
+  public String getQmgrName() {
+    return qmgrName;
+  }
+
+  /** Returns the gateway queue manager name, or {@code null} if not set. */
+  public String getGatewayQmgr() {
+    return gatewayQmgr;
+  }
+
+  /** Returns the HTTP status code of the last command, or {@code null} before any command. */
+  public Integer getLastHttpStatus() {
+    return lastHttpStatus;
+  }
+
+  /** Returns the raw response text of the last command, or {@code null} before any command. */
+  public String getLastResponseText() {
+    return lastResponseText;
+  }
+
+  /**
+   * Returns the parsed response payload of the last command, or {@code null} before any command.
+   * The returned map is unmodifiable.
+   */
+  public Map<String, Object> getLastResponsePayload() {
+    return lastResponsePayload;
+  }
+
+  /**
+   * Returns the command payload sent in the last command, or {@code null} before any command. The
+   * returned map is unmodifiable.
+   */
+  public Map<String, Object> getLastCommandPayload() {
+    return lastCommandPayload;
+  }
+
+  /**
+   * Executes an MQSC command via the MQ REST API.
+   *
+   * @param command the MQSC command (e.g., "DISPLAY")
+   * @param mqscQualifier the MQSC qualifier (e.g., "QUEUE", "QLOCAL")
+   * @param name the object name (e.g., queue name), or null
+   * @param requestParameters request parameters to send, or null
+   * @param responseParameters response parameters to request, or null
+   * @param where a WHERE clause string (e.g., "current_q_depth GT 100"), or null
+   * @return list of response parameter objects
+   */
+  public List<Map<String, Object>> mqscCommand(
+      String command,
+      String mqscQualifier,
+      String name,
+      Map<String, Object> requestParameters,
+      List<String> responseParameters,
+      String where) {
+
+    // 1. Normalize command/qualifier to uppercase
+    String upperCommand = command.toUpperCase(Locale.ROOT);
+    String upperQualifier = mqscQualifier.toUpperCase(Locale.ROOT);
+
+    // 2. Copy requestParameters to mutable map
+    Map<String, Object> params =
+        requestParameters != null ? new LinkedHashMap<>(requestParameters) : new LinkedHashMap<>();
+
+    // 3. Normalize responseParameters
+    boolean isDisplay = "DISPLAY".equals(upperCommand);
+    List<String> respParams = normalizeResponseParameters(responseParameters, isDisplay);
+
+    // 4. Resolve mapping qualifier
+    String mappingQualifier = resolveMappingQualifier(upperCommand, upperQualifier);
+
+    // 5. Map request attributes if enabled
+    if (mapAttributes) {
+      params = attributeMapper.mapRequestAttributes(mappingQualifier, params, mappingStrict);
+      respParams =
+          mapResponseParameters(upperCommand, upperQualifier, mappingQualifier, respParams);
+    }
+
+    // 6. Map WHERE keyword if provided
+    if (where != null && !where.isBlank() && mapAttributes) {
+      where = mapWhereKeyword(where, mappingQualifier);
+    }
+    if (where != null && !where.isBlank()) {
+      params.put("WHERE", where);
+    }
+
+    // 7. Build command payload
+    Map<String, Object> payload =
+        buildCommandPayload(upperCommand, upperQualifier, name, params, respParams);
+    lastCommandPayload = Collections.unmodifiableMap(new LinkedHashMap<>(payload));
+
+    // 8. Execute transport call
+    TransportResponse response =
+        transport.postJson(buildMqscUrl(), payload, buildHeaders(), timeout, verifyTls);
+
+    // 9. Save response state
+    lastHttpStatus = response.statusCode();
+    lastResponseText = response.body();
+
+    // 10. Parse response JSON
+    Map<String, Object> responsePayload = parseResponsePayload(response.body());
+    lastResponsePayload = Collections.unmodifiableMap(new LinkedHashMap<>(responsePayload));
+
+    // 11. Check for command errors
+    raiseForCommandErrors(responsePayload, response.statusCode());
+
+    // 12. Extract commandResponse
+    List<Map<String, Object>> commandResponse = extractCommandResponse(responsePayload);
+
+    // 13. Flatten nested objects
+    commandResponse = flattenNestedObjects(commandResponse);
+
+    // 14. Map response attributes if enabled
+    if (mapAttributes) {
+      commandResponse = normalizeAndMapResponse(commandResponse, mappingQualifier);
+    }
+
+    return commandResponse;
+  }
+
+  private String buildMqscUrl() {
+    return restBaseUrl + "/admin/action/qmgr/" + qmgrName + "/mqsc";
+  }
+
+  private Map<String, String> buildHeaders() {
+    Map<String, String> headers = new LinkedHashMap<>();
+    headers.put("Accept", "application/json");
+    if (credentials instanceof BasicAuth basicAuth) {
+      headers.put(
+          "Authorization", buildBasicAuthHeader(basicAuth.username(), basicAuth.password()));
+    } else if (ltpaToken != null) {
+      headers.put("Cookie", LTPA_COOKIE_NAME + "=" + ltpaToken);
+    }
+    // CertificateAuth: no auth header needed (mTLS handled by transport)
+    if (csrfToken != null) {
+      headers.put("ibm-mq-rest-csrf-token", csrfToken);
+    }
+    if (gatewayQmgr != null) {
+      headers.put(GATEWAY_HEADER, gatewayQmgr);
+    }
+    return headers;
+  }
+
+  static String buildBasicAuthHeader(String username, String password) {
+    String credentials = username + ":" + password;
+    String encoded =
+        Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    return "Basic " + encoded;
+  }
+
+  private void performLtpaLogin(LtpaAuth ltpaAuth) {
+    String loginUrl = restBaseUrl + LTPA_LOGIN_PATH;
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("username", ltpaAuth.username());
+    payload.put("password", ltpaAuth.password());
+
+    Map<String, String> headers = new LinkedHashMap<>();
+    headers.put("Accept", "application/json");
+    if (csrfToken != null) {
+      headers.put("ibm-mq-rest-csrf-token", csrfToken);
+    }
+
+    TransportResponse response = transport.postJson(loginUrl, payload, headers, timeout, verifyTls);
+
+    if (response.statusCode() >= 400) {
+      throw new MqRestAuthException("LTPA login failed", loginUrl, response.statusCode());
+    }
+
+    String token = extractLtpaToken(response.headers());
+    if (token == null) {
+      throw new MqRestAuthException(
+          "LTPA login succeeded but LtpaToken2 cookie not found in response",
+          loginUrl,
+          response.statusCode());
+    }
+    this.ltpaToken = token;
+  }
+
+  static String extractLtpaToken(Map<String, String> headers) {
+    // Look for Set-Cookie header (case-insensitive)
+    String setCookie = null;
+    for (Map.Entry<String, String> entry : headers.entrySet()) {
+      if ("set-cookie".equalsIgnoreCase(entry.getKey())) {
+        setCookie = entry.getValue();
+        break;
+      }
+    }
+    if (setCookie == null) {
+      return null;
+    }
+    // Parse cookie string for LtpaToken2
+    for (String part : setCookie.split(";")) {
+      String trimmed = part.trim();
+      if (trimmed.startsWith(LTPA_COOKIE_NAME + "=")) {
+        return trimmed.substring(LTPA_COOKIE_NAME.length() + 1);
+      }
+    }
+    return null;
+  }
+
+  String resolveMappingQualifier(String command, String qualifier) {
+    // Try command map first
+    String commandKey = command + " " + qualifier;
+    String fromCommand = mappingData.getQualifierForCommand(commandKey);
+    if (fromCommand != null) {
+      return fromCommand;
+    }
+    // Fallback to default mapping qualifiers
+    String fromDefault = DEFAULT_MAPPING_QUALIFIERS.get(qualifier);
+    if (fromDefault != null) {
+      return fromDefault;
+    }
+    // Last resort: lowercase qualifier
+    return qualifier.toLowerCase(Locale.ROOT);
+  }
+
+  static Map<String, Object> buildCommandPayload(
+      String command,
+      String qualifier,
+      String name,
+      Map<String, Object> parameters,
+      List<String> responseParameters) {
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("type", "runCommandJSON");
+    payload.put("command", command);
+    payload.put("qualifier", qualifier);
+    if (name != null && !name.isEmpty()) {
+      payload.put("name", name);
+    }
+    if (!parameters.isEmpty()) {
+      payload.put("parameters", new LinkedHashMap<>(parameters));
+    }
+    if (!responseParameters.isEmpty()) {
+      payload.put("responseParameters", new ArrayList<>(responseParameters));
+    }
+    return payload;
+  }
+
+  static List<String> normalizeResponseParameters(List<String> params, boolean isDisplay) {
+    if (params == null) {
+      return isDisplay ? List.of("all") : List.of();
+    }
+    // Check for "all" (case-insensitive)
+    for (String param : params) {
+      if ("all".equalsIgnoreCase(param)) {
+        return List.of("all");
+      }
+    }
+    return new ArrayList<>(params);
+  }
+
+  static Map<String, Object> parseResponsePayload(String text) {
+    try {
+      Object decoded = GSON.fromJson(text, Object.class);
+      if (!(decoded instanceof Map)) {
+        throw new MqRestResponseException("Response is not a JSON object", text);
+      }
+      @SuppressWarnings("unchecked")
+      Map<String, Object> result = (Map<String, Object>) decoded;
+      return result;
+    } catch (JsonSyntaxException e) {
+      throw new MqRestResponseException("Invalid JSON in response", text, e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  static List<Map<String, Object>> extractCommandResponse(Map<String, Object> payload) {
+    Object commandResponse = payload.get("commandResponse");
+    if (commandResponse == null) {
+      return new ArrayList<>();
+    }
+    if (!(commandResponse instanceof List)) {
+      throw new MqRestResponseException("commandResponse is not a list", null);
+    }
+    List<Map<String, Object>> result = new ArrayList<>();
+    for (Object item : (List<Object>) commandResponse) {
+      if (!(item instanceof Map)) {
+        throw new MqRestResponseException("commandResponse item is not an object", null);
+      }
+      result.add(new LinkedHashMap<>((Map<String, Object>) item));
+    }
+    return result;
+  }
+
+  @SuppressWarnings("unchecked")
+  static void raiseForCommandErrors(Map<String, Object> payload, int statusCode) {
+    Integer overallCompletionCode = extractOptionalInt(payload.get("overallCompletionCode"));
+    Integer overallReasonCode = extractOptionalInt(payload.get("overallReasonCode"));
+
+    boolean hasOverallError = hasErrorCodes(overallCompletionCode, overallReasonCode);
+
+    boolean hasItemError = false;
+    Object commandResponse = payload.get("commandResponse");
+    if (commandResponse instanceof List) {
+      for (Object item : (List<Object>) commandResponse) {
+        if (item instanceof Map) {
+          Map<String, Object> itemMap = (Map<String, Object>) item;
+          Integer completionCode = extractOptionalInt(itemMap.get("completionCode"));
+          Integer reasonCode = extractOptionalInt(itemMap.get("reasonCode"));
+          if (hasErrorCodes(completionCode, reasonCode)) {
+            hasItemError = true;
+            break;
+          }
+        }
+      }
+    }
+
+    if (hasOverallError || hasItemError) {
+      StringBuilder msg = new StringBuilder("MQSC command error");
+      if (overallCompletionCode != null || overallReasonCode != null) {
+        msg.append(" (overallCompletionCode=")
+            .append(overallCompletionCode)
+            .append(", overallReasonCode=")
+            .append(overallReasonCode)
+            .append(")");
+      }
+      throw new MqRestCommandException(msg.toString(), payload, statusCode);
+    }
+  }
+
+  private static boolean hasErrorCodes(Integer completionCode, Integer reasonCode) {
+    return (completionCode != null && completionCode != 0)
+        || (reasonCode != null && reasonCode != 0);
+  }
+
+  @SuppressWarnings("unchecked")
+  static List<Map<String, Object>> flattenNestedObjects(
+      List<Map<String, Object>> parameterObjects) {
+    List<Map<String, Object>> flattened = new ArrayList<>();
+    for (Map<String, Object> item : parameterObjects) {
+      Object objects = item.get("objects");
+      if (objects instanceof List) {
+        Map<String, Object> shared = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry : item.entrySet()) {
+          if (!"objects".equals(entry.getKey())) {
+            shared.put(entry.getKey(), entry.getValue());
+          }
+        }
+        for (Object nested : (List<Object>) objects) {
+          if (nested instanceof Map) {
+            Map<String, Object> merged = new LinkedHashMap<>(shared);
+            merged.putAll((Map<String, Object>) nested);
+            flattened.add(merged);
+          }
+        }
+      } else {
+        flattened.add(item);
+      }
+    }
+    return flattened;
+  }
+
+  static Map<String, Object> normalizeResponseAttributes(Map<String, Object> attrs) {
+    Map<String, Object> normalized = new LinkedHashMap<>();
+    for (Map.Entry<String, Object> entry : attrs.entrySet()) {
+      normalized.put(entry.getKey().toUpperCase(Locale.ROOT), entry.getValue());
+    }
+    return normalized;
+  }
+
+  private List<Map<String, Object>> normalizeAndMapResponse(
+      List<Map<String, Object>> commandResponse, String mappingQualifier) {
+    List<Map<String, Object>> normalized = new ArrayList<>();
+    for (Map<String, Object> item : commandResponse) {
+      normalized.add(normalizeResponseAttributes(item));
+    }
+    return attributeMapper.mapResponseList(mappingQualifier, normalized, mappingStrict);
+  }
+
+  private List<String> mapResponseParameters(
+      String command,
+      String mqscQualifier,
+      String mappingQualifier,
+      List<String> responseParameters) {
+    // "all" passes through unmapped
+    if (responseParameters.size() == 1 && "all".equalsIgnoreCase(responseParameters.get(0))) {
+      return responseParameters;
+    }
+
+    List<String> macros = mappingData.getResponseParameterMacros(command, mqscQualifier);
+    // Build case-insensitive macro lookup
+    Map<String, String> macroLookup = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    for (String macro : macros) {
+      macroLookup.put(macro, macro);
+    }
+
+    Map<String, String> snakeToMqsc = mappingData.getSnakeToMqscMap(mappingQualifier);
+
+    List<MappingIssue> issues = new ArrayList<>();
+    List<String> mapped = new ArrayList<>();
+    for (String param : responseParameters) {
+      // Check macros first (case-insensitive)
+      String macroMatch = macroLookup.get(param);
+      if (macroMatch != null) {
+        mapped.add(macroMatch);
+        continue;
+      }
+      // Check combined snake→MQSC map
+      String mqscName = snakeToMqsc.get(param);
+      if (mqscName != null) {
+        mapped.add(mqscName);
+        continue;
+      }
+      // Unknown parameter
+      issues.add(
+          new MappingIssue(
+              io.github.wphillipmoore.mq.rest.admin.mapping.MappingDirection.REQUEST,
+              io.github.wphillipmoore.mq.rest.admin.mapping.MappingReason.UNKNOWN_KEY,
+              param,
+              null,
+              null,
+              mappingQualifier));
+      mapped.add(param);
+    }
+
+    if (mappingStrict && !issues.isEmpty()) {
+      throw new MappingException(issues);
+    }
+    return mapped;
+  }
+
+  String mapWhereKeyword(String where, String mappingQualifier) {
+    // Split on first whitespace
+    String keyword;
+    String rest;
+    int spaceIdx = indexOfFirstWhitespace(where);
+    if (spaceIdx < 0) {
+      keyword = where;
+      rest = null;
+    } else {
+      keyword = where.substring(0, spaceIdx);
+      rest = where.substring(spaceIdx + 1);
+    }
+
+    Map<String, String> snakeToMqsc = mappingData.getSnakeToMqscMap(mappingQualifier);
+    if (snakeToMqsc.isEmpty() && !mappingData.hasQualifier(mappingQualifier)) {
+      // Unknown qualifier
+      if (mappingStrict) {
+        throw new MappingException(
+            List.of(
+                new MappingIssue(
+                    io.github.wphillipmoore.mq.rest.admin.mapping.MappingDirection.REQUEST,
+                    io.github.wphillipmoore.mq.rest.admin.mapping.MappingReason.UNKNOWN_QUALIFIER,
+                    keyword,
+                    null,
+                    null,
+                    mappingQualifier)));
+      }
+      return where;
+    }
+
+    String mappedKeyword = snakeToMqsc.get(keyword);
+    if (mappedKeyword == null) {
+      if (mappingStrict) {
+        throw new MappingException(
+            List.of(
+                new MappingIssue(
+                    io.github.wphillipmoore.mq.rest.admin.mapping.MappingDirection.REQUEST,
+                    io.github.wphillipmoore.mq.rest.admin.mapping.MappingReason.UNKNOWN_KEY,
+                    keyword,
+                    null,
+                    null,
+                    mappingQualifier)));
+      }
+      return where;
+    }
+
+    if (rest != null) {
+      return mappedKeyword + " " + rest;
+    }
+    return mappedKeyword;
+  }
+
+  private static int indexOfFirstWhitespace(String s) {
+    for (int i = 0; i < s.length(); i++) {
+      if (Character.isWhitespace(s.charAt(i))) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  static Integer extractOptionalInt(Object value) {
+    if (value instanceof Number n) {
+      return n.intValue();
+    }
+    return null;
+  }
+
+  private static String stripTrailingSlashes(String url) {
+    while (url.endsWith("/")) {
+      url = url.substring(0, url.length() - 1);
+    }
+    return url;
+  }
+
+  /** Builder for {@link MqRestSession}. */
+  public static final class Builder {
+
+    private final String restBaseUrl;
+    private final String qmgrName;
+    private final Credentials credentials;
+    private MqRestTransport transport;
+    private String gatewayQmgr;
+    private boolean verifyTls = true;
+    private Duration timeout = DEFAULT_TIMEOUT;
+    private boolean mapAttributes = true;
+    private boolean mappingStrict = true;
+    private Map<String, Object> mappingOverrides;
+    private MappingOverrideMode mappingOverridesMode = MappingOverrideMode.MERGE;
+    private String csrfToken = DEFAULT_CSRF_TOKEN;
+
+    /**
+     * Creates a builder with the required session parameters.
+     *
+     * @param restBaseUrl the base URL of the MQ REST API
+     * @param qmgrName the queue manager name
+     * @param credentials the authentication credentials
+     */
+    public Builder(String restBaseUrl, String qmgrName, Credentials credentials) {
+      this.restBaseUrl = Objects.requireNonNull(restBaseUrl, "restBaseUrl");
+      this.qmgrName = Objects.requireNonNull(qmgrName, "qmgrName");
+      this.credentials = Objects.requireNonNull(credentials, "credentials");
+    }
+
+    /** Sets the transport implementation. Required before calling {@link #build()}. */
+    public Builder transport(MqRestTransport transport) {
+      this.transport = Objects.requireNonNull(transport, "transport");
+      return this;
+    }
+
+    /** Sets the gateway queue manager name. */
+    public Builder gatewayQmgr(String gatewayQmgr) {
+      this.gatewayQmgr = gatewayQmgr;
+      return this;
+    }
+
+    /** Sets whether to verify TLS certificates. Defaults to {@code true}. */
+    public Builder verifyTls(boolean verifyTls) {
+      this.verifyTls = verifyTls;
+      return this;
+    }
+
+    /** Sets the request timeout. Defaults to 30 seconds. Pass {@code null} for no timeout. */
+    public Builder timeout(Duration timeout) {
+      this.timeout = timeout;
+      return this;
+    }
+
+    /** Sets whether to enable attribute mapping. Defaults to {@code true}. */
+    public Builder mapAttributes(boolean mapAttributes) {
+      this.mapAttributes = mapAttributes;
+      return this;
+    }
+
+    /** Sets whether attribute mapping uses strict mode. Defaults to {@code true}. */
+    public Builder mappingStrict(boolean mappingStrict) {
+      this.mappingStrict = mappingStrict;
+      return this;
+    }
+
+    /** Sets mapping overrides to apply on top of the default mapping data. */
+    public Builder mappingOverrides(Map<String, Object> mappingOverrides) {
+      this.mappingOverrides =
+          mappingOverrides != null ? new LinkedHashMap<>(mappingOverrides) : null;
+      return this;
+    }
+
+    /** Sets the override mode. Defaults to {@link MappingOverrideMode#MERGE}. */
+    public Builder mappingOverridesMode(MappingOverrideMode mappingOverridesMode) {
+      this.mappingOverridesMode =
+          Objects.requireNonNull(mappingOverridesMode, "mappingOverridesMode");
+      return this;
+    }
+
+    /** Sets the CSRF token. Defaults to {@code "local"}. Pass {@code null} to omit the header. */
+    public Builder csrfToken(String csrfToken) {
+      this.csrfToken = csrfToken;
+      return this;
+    }
+
+    /**
+     * Builds the session.
+     *
+     * @return the configured session
+     * @throws NullPointerException if transport has not been set
+     */
+    public MqRestSession build() {
+      Objects.requireNonNull(transport, "transport");
+      return new MqRestSession(this);
+    }
+  }
+}

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionTest.java
@@ -1,0 +1,1521 @@
+package io.github.wphillipmoore.mq.rest.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.wphillipmoore.mq.rest.admin.auth.BasicAuth;
+import io.github.wphillipmoore.mq.rest.admin.auth.CertificateAuth;
+import io.github.wphillipmoore.mq.rest.admin.auth.LtpaAuth;
+import io.github.wphillipmoore.mq.rest.admin.exception.MqRestAuthException;
+import io.github.wphillipmoore.mq.rest.admin.exception.MqRestCommandException;
+import io.github.wphillipmoore.mq.rest.admin.exception.MqRestResponseException;
+import io.github.wphillipmoore.mq.rest.admin.mapping.MappingException;
+import io.github.wphillipmoore.mq.rest.admin.mapping.MappingOverrideMode;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MqRestSessionTest {
+
+  private static final String BASE_URL = "https://host:9443/ibmmq/rest/v2";
+  private static final String QMGR = "QM1";
+
+  @Mock private MqRestTransport transport;
+
+  private TransportResponse successResponse(String body) {
+    return new TransportResponse(200, body, Map.of());
+  }
+
+  private TransportResponse successResponseWithHeaders(String body, Map<String, String> headers) {
+    return new TransportResponse(200, body, headers);
+  }
+
+  private String emptyCommandResponse() {
+    return "{\"overallCompletionCode\":0,\"overallReasonCode\":0,\"commandResponse\":[]}";
+  }
+
+  private String commandResponseWithParams(String paramsJson) {
+    return "{\"overallCompletionCode\":0,\"overallReasonCode\":0,"
+        + "\"commandResponse\":[{\"parameters\":{"
+        + paramsJson
+        + "}}]}";
+  }
+
+  private MqRestSession.Builder basicBuilder() {
+    return new MqRestSession.Builder(BASE_URL, QMGR, new BasicAuth("user", "pass"))
+        .transport(transport);
+  }
+
+  private MqRestSession buildSessionNoMapping() {
+    return basicBuilder().mapAttributes(false).build();
+  }
+
+  @Nested
+  class BuilderValidation {
+
+    @Test
+    void buildSucceedsWithRequiredParams() {
+      MqRestSession session = basicBuilder().build();
+
+      assertThat(session.getQmgrName()).isEqualTo(QMGR);
+    }
+
+    @Test
+    void builderNullRestBaseUrlThrowsNpe() {
+      assertThatThrownBy(() -> new MqRestSession.Builder(null, QMGR, new BasicAuth("u", "p")))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessage("restBaseUrl");
+    }
+
+    @Test
+    void builderNullQmgrNameThrowsNpe() {
+      assertThatThrownBy(() -> new MqRestSession.Builder(BASE_URL, null, new BasicAuth("u", "p")))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessage("qmgrName");
+    }
+
+    @Test
+    void builderNullCredentialsThrowsNpe() {
+      assertThatThrownBy(() -> new MqRestSession.Builder(BASE_URL, QMGR, null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessage("credentials");
+    }
+
+    @Test
+    void buildWithoutTransportThrowsNpe() {
+      assertThatThrownBy(
+              () -> new MqRestSession.Builder(BASE_URL, QMGR, new BasicAuth("u", "p")).build())
+          .isInstanceOf(NullPointerException.class)
+          .hasMessage("transport");
+    }
+
+    @Test
+    void builderDefaultValues() {
+      MqRestSession session = basicBuilder().build();
+
+      assertThat(session.getGatewayQmgr()).isNull();
+    }
+
+    @Test
+    void builderCustomGatewayQmgr() {
+      MqRestSession session = basicBuilder().gatewayQmgr("GWQM").build();
+
+      assertThat(session.getGatewayQmgr()).isEqualTo("GWQM");
+    }
+
+    @Test
+    void builderStripsTrailingSlashesFromUrl() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session =
+          new MqRestSession.Builder(BASE_URL + "///", QMGR, new BasicAuth("u", "p"))
+              .transport(transport)
+              .mapAttributes(false)
+              .build();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+      verify(transport).postJson(urlCaptor.capture(), anyMap(), anyMap(), any(), anyBoolean());
+      assertThat(urlCaptor.getValue()).startsWith(BASE_URL + "/admin");
+    }
+  }
+
+  @Nested
+  class LtpaLogin {
+
+    @Test
+    void ltpaAuthPerformsLoginAtConstruction() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(
+              successResponseWithHeaders("{}", Map.of("Set-Cookie", "LtpaToken2=abc123; Path=/")));
+
+      MqRestSession session =
+          new MqRestSession.Builder(BASE_URL, QMGR, new LtpaAuth("user", "pass"))
+              .transport(transport)
+              .build();
+
+      assertThat(session).isNotNull();
+      ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+      verify(transport).postJson(urlCaptor.capture(), anyMap(), anyMap(), any(), anyBoolean());
+      assertThat(urlCaptor.getValue()).isEqualTo(BASE_URL + "/login");
+    }
+
+    @Test
+    void ltpaLoginFailsOnHttpError() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(new TransportResponse(401, "Unauthorized", Map.of()));
+
+      assertThatThrownBy(
+              () ->
+                  new MqRestSession.Builder(BASE_URL, QMGR, new LtpaAuth("user", "pass"))
+                      .transport(transport)
+                      .build())
+          .isInstanceOf(MqRestAuthException.class)
+          .hasMessageContaining("LTPA login failed");
+    }
+
+    @Test
+    void ltpaLoginFailsWhenTokenMissing() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse("{}"));
+
+      assertThatThrownBy(
+              () ->
+                  new MqRestSession.Builder(BASE_URL, QMGR, new LtpaAuth("user", "pass"))
+                      .transport(transport)
+                      .build())
+          .isInstanceOf(MqRestAuthException.class)
+          .hasMessageContaining("LtpaToken2");
+    }
+
+    @Test
+    void basicAuthSkipsLogin() {
+      MqRestSession session = basicBuilder().build();
+
+      assertThat(session).isNotNull();
+    }
+
+    @Test
+    void certificateAuthSkipsLogin() {
+      MqRestSession session =
+          new MqRestSession.Builder(BASE_URL, QMGR, new CertificateAuth("/cert.pem"))
+              .transport(transport)
+              .build();
+
+      assertThat(session).isNotNull();
+    }
+
+    @Test
+    void ltpaLoginSendsCsrfTokenInHeaders() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(
+              successResponseWithHeaders("{}", Map.of("Set-Cookie", "LtpaToken2=tok; Path=/")));
+
+      new MqRestSession.Builder(BASE_URL, QMGR, new LtpaAuth("user", "pass"))
+          .transport(transport)
+          .csrfToken("mytoken")
+          .build();
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), anyMap(), headersCaptor.capture(), any(), anyBoolean());
+      assertThat(headersCaptor.getValue()).containsEntry("ibm-mq-rest-csrf-token", "mytoken");
+    }
+  }
+
+  @Nested
+  class Headers {
+
+    @Test
+    void basicAuthIncludesAuthorizationHeader() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), anyMap(), headersCaptor.capture(), any(), anyBoolean());
+      assertThat(headersCaptor.getValue()).containsKey("Authorization");
+      assertThat(headersCaptor.getValue().get("Authorization")).startsWith("Basic ");
+    }
+
+    @Test
+    void ltpaAuthIncludesCookieHeader() {
+      // First call: LTPA login
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(
+              successResponseWithHeaders("{}", Map.of("Set-Cookie", "LtpaToken2=tok123; Path=/")))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session =
+          new MqRestSession.Builder(BASE_URL, QMGR, new LtpaAuth("user", "pass"))
+              .transport(transport)
+              .mapAttributes(false)
+              .build();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport, times(2))
+          .postJson(anyString(), anyMap(), headersCaptor.capture(), any(), anyBoolean());
+      // The second call's headers should have Cookie
+      List<Map<String, String>> allHeaders = headersCaptor.getAllValues();
+      Map<String, String> commandHeaders = allHeaders.get(1);
+      assertThat(commandHeaders).containsEntry("Cookie", "LtpaToken2=tok123");
+    }
+
+    @Test
+    void certificateAuthOmitsAuthHeader() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session =
+          new MqRestSession.Builder(BASE_URL, QMGR, new CertificateAuth("/cert.pem"))
+              .transport(transport)
+              .mapAttributes(false)
+              .build();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), anyMap(), headersCaptor.capture(), any(), anyBoolean());
+      assertThat(headersCaptor.getValue()).doesNotContainKey("Authorization");
+      assertThat(headersCaptor.getValue()).doesNotContainKey("Cookie");
+    }
+
+    @Test
+    void csrfTokenIncludedByDefault() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), anyMap(), headersCaptor.capture(), any(), anyBoolean());
+      assertThat(headersCaptor.getValue())
+          .containsEntry("ibm-mq-rest-csrf-token", MqRestSession.DEFAULT_CSRF_TOKEN);
+    }
+
+    @Test
+    void csrfTokenOmittedWhenNull() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = basicBuilder().csrfToken(null).mapAttributes(false).build();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), anyMap(), headersCaptor.capture(), any(), anyBoolean());
+      assertThat(headersCaptor.getValue()).doesNotContainKey("ibm-mq-rest-csrf-token");
+    }
+
+    @Test
+    void gatewayHeaderIncludedWhenSet() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = basicBuilder().gatewayQmgr("GWQM").mapAttributes(false).build();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), anyMap(), headersCaptor.capture(), any(), anyBoolean());
+      assertThat(headersCaptor.getValue()).containsEntry(MqRestSession.GATEWAY_HEADER, "GWQM");
+    }
+
+    @Test
+    void gatewayHeaderOmittedWhenNull() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), anyMap(), headersCaptor.capture(), any(), anyBoolean());
+      assertThat(headersCaptor.getValue()).doesNotContainKey(MqRestSession.GATEWAY_HEADER);
+    }
+  }
+
+  @Nested
+  class MqscCommandFlow {
+
+    @Test
+    void simpleDisplayCommand() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      List<Map<String, Object>> result =
+          session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void commandWithName() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("DISPLAY", "QUEUE", "MY.QUEUE", null, null, null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      assertThat(payloadCaptor.getValue()).containsEntry("name", "MY.QUEUE");
+    }
+
+    @Test
+    void commandWithoutNameOmitsNameField() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      assertThat(payloadCaptor.getValue()).doesNotContainKey("name");
+    }
+
+    @Test
+    void commandWithRequestParameters() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("ALTER", "QUEUE", "Q1", Map.of("MAXDEPTH", 5000), null, null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      @SuppressWarnings("unchecked")
+      Map<String, Object> params = (Map<String, Object>) payloadCaptor.getValue().get("parameters");
+      assertThat(params).containsEntry("MAXDEPTH", 5000);
+    }
+
+    @Test
+    void commandWithResponseParameters() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("DISPLAY", "QUEUE", "Q1", null, List.of("MAXDEPTH", "CURDEPTH"), null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      @SuppressWarnings("unchecked")
+      List<String> respParams = (List<String>) payloadCaptor.getValue().get("responseParameters");
+      assertThat(respParams).containsExactly("MAXDEPTH", "CURDEPTH");
+    }
+
+    @Test
+    void displayWithNullResponseParamsDefaultsToAll() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("DISPLAY", "QUEUE", "Q1", null, null, null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      @SuppressWarnings("unchecked")
+      List<String> respParams = (List<String>) payloadCaptor.getValue().get("responseParameters");
+      assertThat(respParams).containsExactly("all");
+    }
+
+    @Test
+    void nonDisplayWithNullResponseParamsOmitsField() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("ALTER", "QUEUE", "Q1", null, null, null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      assertThat(payloadCaptor.getValue()).doesNotContainKey("responseParameters");
+    }
+
+    @Test
+    void commandUrlIsCorrect() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+      verify(transport).postJson(urlCaptor.capture(), anyMap(), anyMap(), any(), anyBoolean());
+      assertThat(urlCaptor.getValue()).isEqualTo(BASE_URL + "/admin/action/qmgr/QM1/mqsc");
+    }
+
+    @Test
+    void commandPayloadHasCorrectType() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      assertThat(payloadCaptor.getValue())
+          .containsEntry("type", "runCommandJSON")
+          .containsEntry("command", "DISPLAY")
+          .containsEntry("qualifier", "QUEUE");
+    }
+  }
+
+  @Nested
+  class SessionState {
+
+    @Test
+    void stateIsNullBeforeFirstCommand() {
+      MqRestSession session = basicBuilder().mapAttributes(false).build();
+
+      assertThat(session.getLastHttpStatus()).isNull();
+      assertThat(session.getLastResponseText()).isNull();
+      assertThat(session.getLastResponsePayload()).isNull();
+      assertThat(session.getLastCommandPayload()).isNull();
+    }
+
+    @Test
+    void stateUpdatedAfterCommand() {
+      String responseBody = emptyCommandResponse();
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(responseBody));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      assertThat(session.getLastHttpStatus()).isEqualTo(200);
+      assertThat(session.getLastResponseText()).isEqualTo(responseBody);
+      assertThat(session.getLastResponsePayload()).isNotNull();
+      assertThat(session.getLastCommandPayload()).isNotNull();
+    }
+
+    @Test
+    void lastResponsePayloadIsUnmodifiable() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      assertThatThrownBy(() -> session.getLastResponsePayload().put("new", "value"))
+          .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void lastCommandPayloadIsUnmodifiable() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      assertThatThrownBy(() -> session.getLastCommandPayload().put("new", "value"))
+          .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void lastCommandPayloadContainsExpectedFields() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("DISPLAY", "QUEUE", "Q1", null, null, null);
+
+      assertThat(session.getLastCommandPayload())
+          .containsEntry("type", "runCommandJSON")
+          .containsEntry("command", "DISPLAY")
+          .containsEntry("qualifier", "QUEUE")
+          .containsEntry("name", "Q1");
+    }
+  }
+
+  @Nested
+  class ResponseParsing {
+
+    @Test
+    void invalidJsonThrowsResponseException() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse("not valid json{{{"));
+
+      MqRestSession session = buildSessionNoMapping();
+
+      assertThatThrownBy(() -> session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null))
+          .isInstanceOf(MqRestResponseException.class)
+          .hasMessageContaining("Invalid JSON");
+    }
+
+    @Test
+    void nonObjectResponseThrowsResponseException() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse("[1, 2, 3]"));
+
+      MqRestSession session = buildSessionNoMapping();
+
+      assertThatThrownBy(() -> session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null))
+          .isInstanceOf(MqRestResponseException.class)
+          .hasMessageContaining("not a JSON object");
+    }
+
+    @Test
+    void commandResponseNotListThrowsResponseException() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(
+              successResponse(
+                  "{\"overallCompletionCode\":0,\"overallReasonCode\":0,"
+                      + "\"commandResponse\":\"not a list\"}"));
+
+      MqRestSession session = buildSessionNoMapping();
+
+      assertThatThrownBy(() -> session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null))
+          .isInstanceOf(MqRestResponseException.class)
+          .hasMessageContaining("commandResponse is not a list");
+    }
+
+    @Test
+    void commandResponseItemNotObjectThrowsResponseException() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(
+              successResponse(
+                  "{\"overallCompletionCode\":0,\"overallReasonCode\":0,"
+                      + "\"commandResponse\":[\"not an object\"]}"));
+
+      MqRestSession session = buildSessionNoMapping();
+
+      assertThatThrownBy(() -> session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null))
+          .isInstanceOf(MqRestResponseException.class)
+          .hasMessageContaining("item is not an object");
+    }
+  }
+
+  @Nested
+  class ErrorDetection {
+
+    @Test
+    void overallErrorCodesThrowCommandException() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(
+              successResponse(
+                  "{\"overallCompletionCode\":2,\"overallReasonCode\":3008,"
+                      + "\"commandResponse\":[]}"));
+
+      MqRestSession session = buildSessionNoMapping();
+
+      assertThatThrownBy(() -> session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null))
+          .isInstanceOf(MqRestCommandException.class)
+          .hasMessageContaining("MQSC command error");
+    }
+
+    @Test
+    void perItemErrorCodesThrowCommandException() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(
+              successResponse(
+                  "{\"overallCompletionCode\":0,\"overallReasonCode\":0,"
+                      + "\"commandResponse\":[{\"completionCode\":2,\"reasonCode\":2085}]}"));
+
+      MqRestSession session = buildSessionNoMapping();
+
+      assertThatThrownBy(() -> session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null))
+          .isInstanceOf(MqRestCommandException.class);
+    }
+
+    @Test
+    void zeroCodesDoNotThrow() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(
+              successResponse(
+                  "{\"overallCompletionCode\":0,\"overallReasonCode\":0,"
+                      + "\"commandResponse\":[{\"completionCode\":0,\"reasonCode\":0}]}"));
+
+      MqRestSession session = buildSessionNoMapping();
+      List<Map<String, Object>> result =
+          session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void missingCodesDoNotThrow() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse("{\"commandResponse\":[{\"parameters\":{}}]}"));
+
+      MqRestSession session = buildSessionNoMapping();
+      List<Map<String, Object>> result =
+          session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void onlyReasonCodeNonZeroThrows() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(
+              successResponse(
+                  "{\"overallCompletionCode\":0,\"overallReasonCode\":3008,"
+                      + "\"commandResponse\":[]}"));
+
+      MqRestSession session = buildSessionNoMapping();
+
+      assertThatThrownBy(() -> session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null))
+          .isInstanceOf(MqRestCommandException.class);
+    }
+  }
+
+  @Nested
+  class NestedObjectFlattening {
+
+    @Test
+    void flattenWithObjectsKey() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(
+              successResponse(
+                  "{\"overallCompletionCode\":0,\"overallReasonCode\":0,"
+                      + "\"commandResponse\":[{\"shared\":\"val\","
+                      + "\"objects\":[{\"nested1\":\"a\"},{\"nested2\":\"b\"}]}]}"));
+
+      MqRestSession session = buildSessionNoMapping();
+      List<Map<String, Object>> result =
+          session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      assertThat(result).hasSize(2);
+      assertThat(result.get(0)).containsEntry("shared", "val").containsEntry("nested1", "a");
+      assertThat(result.get(1)).containsEntry("shared", "val").containsEntry("nested2", "b");
+    }
+
+    @Test
+    void flattenWithoutObjectsKeyPassesThrough() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(
+              successResponse(
+                  "{\"overallCompletionCode\":0,\"overallReasonCode\":0,"
+                      + "\"commandResponse\":[{\"key\":\"value\"}]}"));
+
+      MqRestSession session = buildSessionNoMapping();
+      List<Map<String, Object>> result =
+          session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0)).containsEntry("key", "value");
+    }
+
+    @Test
+    void flattenMergesSharedFieldsWithNested() {
+      Map<String, Object> item = new LinkedHashMap<>();
+      item.put("type", "queue");
+      item.put("objects", List.of(Map.of("name", "Q1"), Map.of("name", "Q2")));
+
+      List<Map<String, Object>> result = MqRestSession.flattenNestedObjects(List.of(item));
+
+      assertThat(result).hasSize(2);
+      assertThat(result.get(0)).containsEntry("type", "queue").containsEntry("name", "Q1");
+      assertThat(result.get(1)).containsEntry("type", "queue").containsEntry("name", "Q2");
+      // Verify "objects" key is removed
+      assertThat(result.get(0)).doesNotContainKey("objects");
+    }
+  }
+
+  @Nested
+  class AttributeMappingIntegration {
+
+    @Test
+    void mapAttributesTrueMapsResponseKeys() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(
+              successResponse(
+                  "{\"overallCompletionCode\":0,\"overallReasonCode\":0,"
+                      + "\"commandResponse\":[{\"MAXDEPTH\":5000}]}"));
+
+      MqRestSession session = basicBuilder().mapAttributes(true).mappingStrict(false).build();
+      List<Map<String, Object>> result =
+          session.mqscCommand("DISPLAY", "QUEUE", "Q1", null, null, null);
+
+      assertThat(result).hasSize(1);
+      // Should have mapped MAXDEPTH → max_depth
+      assertThat(result.get(0)).containsKey("max_depth");
+    }
+
+    @Test
+    void mapAttributesFalsePreservesOriginalKeys() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(
+              successResponse(
+                  "{\"overallCompletionCode\":0,\"overallReasonCode\":0,"
+                      + "\"commandResponse\":[{\"MAXDEPTH\":5000}]}"));
+
+      MqRestSession session = buildSessionNoMapping();
+      List<Map<String, Object>> result =
+          session.mqscCommand("DISPLAY", "QUEUE", "Q1", null, null, null);
+
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0)).containsKey("MAXDEPTH");
+    }
+
+    @Test
+    void requestAttributesMappedWhenEnabled() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = basicBuilder().mapAttributes(true).mappingStrict(false).build();
+      session.mqscCommand("ALTER", "QUEUE", "Q1", Map.of("max_depth", 5000), null, null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      @SuppressWarnings("unchecked")
+      Map<String, Object> params = (Map<String, Object>) payloadCaptor.getValue().get("parameters");
+      assertThat(params).containsKey("MAXDEPTH");
+    }
+
+    @Test
+    void responseNormalizationUppercasesKeys() {
+      Map<String, Object> attrs = Map.of("maxdepth", 5000, "CurDepth", 100);
+
+      Map<String, Object> normalized = MqRestSession.normalizeResponseAttributes(attrs);
+
+      assertThat(normalized).containsKey("MAXDEPTH").containsKey("CURDEPTH");
+    }
+  }
+
+  @Nested
+  class QualifierResolution {
+
+    @Test
+    void commandMapHitResolvesQualifier() {
+      MqRestSession session = basicBuilder().mapAttributes(false).build();
+
+      // "DISPLAY QUEUE" is in the default mapping data → "queue"
+      String result = session.resolveMappingQualifier("DISPLAY", "QUEUE");
+
+      assertThat(result).isEqualTo("queue");
+    }
+
+    @Test
+    void fallbackMapResolvesQualifier() {
+      MqRestSession session = basicBuilder().mapAttributes(false).build();
+
+      // QLOCAL should fall back to DEFAULT_MAPPING_QUALIFIERS → "queue"
+      String result = session.resolveMappingQualifier("DEFINE", "QLOCAL");
+
+      assertThat(result).isEqualTo("queue");
+    }
+
+    @Test
+    void lowercaseFallbackForUnknownQualifier() {
+      MqRestSession session = basicBuilder().mapAttributes(false).build();
+
+      String result = session.resolveMappingQualifier("DISPLAY", "UNKNOWN");
+
+      assertThat(result).isEqualTo("unknown");
+    }
+  }
+
+  @Nested
+  class ResponseParameterMapping {
+
+    @Test
+    void allPassesThrough() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = basicBuilder().mappingStrict(false).build();
+      session.mqscCommand("DISPLAY", "QUEUE", "Q1", null, List.of("all"), null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      @SuppressWarnings("unchecked")
+      List<String> respParams = (List<String>) payloadCaptor.getValue().get("responseParameters");
+      assertThat(respParams).containsExactly("all");
+    }
+
+    @Test
+    void snakeCaseParamMappedToMqsc() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = basicBuilder().mappingStrict(false).build();
+      session.mqscCommand("DISPLAY", "QUEUE", "Q1", null, List.of("max_depth"), null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      @SuppressWarnings("unchecked")
+      List<String> respParams = (List<String>) payloadCaptor.getValue().get("responseParameters");
+      assertThat(respParams).containsExactly("MAXDEPTH");
+    }
+
+    @Test
+    void unknownParamStrictThrows() {
+      MqRestSession session = basicBuilder().mappingStrict(true).build();
+
+      assertThatThrownBy(
+              () ->
+                  session.mqscCommand(
+                      "DISPLAY", "QUEUE", "Q1", null, List.of("unknown_param"), null))
+          .isInstanceOf(MappingException.class);
+    }
+
+    @Test
+    void unknownParamPermissivePassesThrough() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = basicBuilder().mappingStrict(false).build();
+      session.mqscCommand("DISPLAY", "QUEUE", "Q1", null, List.of("unknown_param"), null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      @SuppressWarnings("unchecked")
+      List<String> respParams = (List<String>) payloadCaptor.getValue().get("responseParameters");
+      assertThat(respParams).containsExactly("unknown_param");
+    }
+
+    @Test
+    void unknownQualifierStrictThrowsForResponseParams() {
+      MqRestSession session = basicBuilder().mappingStrict(true).build();
+
+      assertThatThrownBy(
+              () ->
+                  session.mqscCommand("DISPLAY", "XYZOBJ", "X1", null, List.of("some_param"), null))
+          .isInstanceOf(MappingException.class);
+    }
+
+    @Test
+    void unknownQualifierPermissivePassesThroughResponseParams() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = basicBuilder().mappingStrict(false).build();
+      session.mqscCommand("DISPLAY", "XYZOBJ", "X1", null, List.of("some_param"), null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      @SuppressWarnings("unchecked")
+      List<String> respParams = (List<String>) payloadCaptor.getValue().get("responseParameters");
+      assertThat(respParams).containsExactly("some_param");
+    }
+
+    @Test
+    void macroParameterMapped() {
+      // Use mapping data with macros for DISPLAY QUEUE → CLUSINFO
+      String json =
+          "{\"commands\":{\"DISPLAY QUEUE\":{\"qualifier\":\"queue\","
+              + "\"response_parameter_macros\":[\"CLUSINFO\"]}},"
+              + "\"qualifiers\":{\"queue\":{\"request_key_map\":{},\"response_key_map\":{}}}}";
+      Map<String, Object> overrides =
+          new com.google.gson.Gson()
+              .fromJson(
+                  json, new com.google.gson.reflect.TypeToken<Map<String, Object>>() {}.getType());
+
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session =
+          basicBuilder()
+              .mappingStrict(false)
+              .mappingOverrides(overrides)
+              .mappingOverridesMode(MappingOverrideMode.MERGE)
+              .build();
+      session.mqscCommand("DISPLAY", "QUEUE", "Q1", null, List.of("CLUSINFO"), null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      @SuppressWarnings("unchecked")
+      List<String> respParams = (List<String>) payloadCaptor.getValue().get("responseParameters");
+      assertThat(respParams).containsExactly("CLUSINFO");
+    }
+  }
+
+  @Nested
+  class WhereMapping {
+
+    @Test
+    void whereKeywordMapped() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = basicBuilder().mappingStrict(false).build();
+      session.mqscCommand("DISPLAY", "QUEUE", "*", null, null, "max_depth GT 5000");
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      @SuppressWarnings("unchecked")
+      Map<String, Object> params = (Map<String, Object>) payloadCaptor.getValue().get("parameters");
+      assertThat(params).containsKey("WHERE");
+      assertThat((String) params.get("WHERE")).isEqualTo("MAXDEPTH GT 5000");
+    }
+
+    @Test
+    void whereKeywordWithoutRestPartMapped() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = basicBuilder().mappingStrict(false).build();
+      session.mqscCommand("DISPLAY", "QUEUE", "*", null, null, "max_depth");
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      @SuppressWarnings("unchecked")
+      Map<String, Object> params = (Map<String, Object>) payloadCaptor.getValue().get("parameters");
+      assertThat((String) params.get("WHERE")).isEqualTo("MAXDEPTH");
+    }
+
+    @Test
+    void unknownWhereKeywordStrictThrows() {
+      MqRestSession session = basicBuilder().mappingStrict(true).build();
+
+      assertThatThrownBy(
+              () -> session.mqscCommand("DISPLAY", "QUEUE", "*", null, null, "unknown_key GT 100"))
+          .isInstanceOf(MappingException.class);
+    }
+
+    @Test
+    void unknownWhereKeywordPermissivePassesThrough() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = basicBuilder().mappingStrict(false).build();
+      session.mqscCommand("DISPLAY", "QUEUE", "*", null, null, "unknown_key GT 100");
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      @SuppressWarnings("unchecked")
+      Map<String, Object> params = (Map<String, Object>) payloadCaptor.getValue().get("parameters");
+      assertThat((String) params.get("WHERE")).isEqualTo("unknown_key GT 100");
+    }
+
+    @Test
+    void blankWhereIsSkipped() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, "   ");
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      assertThat(payloadCaptor.getValue()).doesNotContainKey("parameters");
+    }
+
+    @Test
+    void nullWhereIsSkipped() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      assertThat(payloadCaptor.getValue()).doesNotContainKey("parameters");
+    }
+
+    @Test
+    void unknownQualifierWhereStrictThrows() {
+      MqRestSession session = basicBuilder().mappingStrict(true).build();
+
+      assertThatThrownBy(
+              () -> session.mqscCommand("DISPLAY", "XYZOBJ", "*", null, null, "some_key GT 100"))
+          .isInstanceOf(MappingException.class);
+    }
+
+    @Test
+    void mapWhereKeywordUnknownQualifierStrictThrowsDirectly() {
+      MqRestSession session = basicBuilder().mappingStrict(true).build();
+
+      assertThatThrownBy(() -> session.mapWhereKeyword("some_key GT 100", "nonexistent_qualifier"))
+          .isInstanceOf(MappingException.class);
+    }
+
+    @Test
+    void mapWhereKeywordUnknownQualifierPermissivePassesThroughDirectly() {
+      MqRestSession session = basicBuilder().mappingStrict(false).build();
+
+      String result = session.mapWhereKeyword("some_key GT 100", "nonexistent_qualifier");
+
+      assertThat(result).isEqualTo("some_key GT 100");
+    }
+  }
+
+  @Nested
+  class StaticHelpers {
+
+    @Test
+    void buildBasicAuthHeaderEncodesCorrectly() {
+      String header = MqRestSession.buildBasicAuthHeader("user", "pass");
+
+      assertThat(header).isEqualTo("Basic dXNlcjpwYXNz");
+    }
+
+    @Test
+    void buildBasicAuthHeaderHandlesSpecialCharacters() {
+      String header = MqRestSession.buildBasicAuthHeader("user@domain", "p@ss:word");
+
+      assertThat(header).startsWith("Basic ");
+      String encoded = header.substring("Basic ".length());
+      String decoded =
+          new String(
+              java.util.Base64.getDecoder().decode(encoded),
+              java.nio.charset.StandardCharsets.UTF_8);
+      assertThat(decoded).isEqualTo("user@domain:p@ss:word");
+    }
+
+    @Test
+    void extractLtpaTokenFromSetCookie() {
+      String token =
+          MqRestSession.extractLtpaToken(Map.of("Set-Cookie", "LtpaToken2=mytoken; Path=/"));
+
+      assertThat(token).isEqualTo("mytoken");
+    }
+
+    @Test
+    void extractLtpaTokenCaseInsensitiveHeader() {
+      String token =
+          MqRestSession.extractLtpaToken(Map.of("set-cookie", "LtpaToken2=mytoken; Path=/"));
+
+      assertThat(token).isEqualTo("mytoken");
+    }
+
+    @Test
+    void extractLtpaTokenReturnsNullWhenNoSetCookie() {
+      String token = MqRestSession.extractLtpaToken(Map.of("Content-Type", "text/html"));
+
+      assertThat(token).isNull();
+    }
+
+    @Test
+    void extractLtpaTokenReturnsNullWhenWrongCookieName() {
+      String token =
+          MqRestSession.extractLtpaToken(Map.of("Set-Cookie", "JSESSIONID=abc123; Path=/"));
+
+      assertThat(token).isNull();
+    }
+
+    @Test
+    void extractOptionalIntFromDouble() {
+      Integer result = MqRestSession.extractOptionalInt(2.0);
+
+      assertThat(result).isEqualTo(2);
+    }
+
+    @Test
+    void extractOptionalIntFromInteger() {
+      Integer result = MqRestSession.extractOptionalInt(42);
+
+      assertThat(result).isEqualTo(42);
+    }
+
+    @Test
+    void extractOptionalIntFromNullReturnsNull() {
+      Integer result = MqRestSession.extractOptionalInt(null);
+
+      assertThat(result).isNull();
+    }
+
+    @Test
+    void extractOptionalIntFromStringReturnsNull() {
+      Integer result = MqRestSession.extractOptionalInt("not a number");
+
+      assertThat(result).isNull();
+    }
+
+    @Test
+    void normalizeResponseParametersNullDisplayDefaultsToAll() {
+      List<String> result = MqRestSession.normalizeResponseParameters(null, true);
+
+      assertThat(result).containsExactly("all");
+    }
+
+    @Test
+    void normalizeResponseParametersNullNonDisplayReturnsEmpty() {
+      List<String> result = MqRestSession.normalizeResponseParameters(null, false);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void normalizeResponseParametersDetectsAllCaseInsensitive() {
+      List<String> result =
+          MqRestSession.normalizeResponseParameters(List.of("param1", "ALL"), false);
+
+      assertThat(result).containsExactly("all");
+    }
+
+    @Test
+    void normalizeResponseParametersCopiesList() {
+      List<String> result =
+          MqRestSession.normalizeResponseParameters(List.of("MAXDEPTH", "CURDEPTH"), true);
+
+      assertThat(result).containsExactly("MAXDEPTH", "CURDEPTH");
+    }
+
+    @Test
+    void parseResponsePayloadParsesValidJson() {
+      Map<String, Object> result = MqRestSession.parseResponsePayload("{\"key\":\"value\"}");
+
+      assertThat(result).containsEntry("key", "value");
+    }
+
+    @Test
+    void buildCommandPayloadIncludesAllFields() {
+      Map<String, Object> payload =
+          MqRestSession.buildCommandPayload(
+              "DISPLAY", "QUEUE", "Q1", Map.of("MAXDEPTH", 5000), List.of("all"));
+
+      assertThat(payload)
+          .containsEntry("type", "runCommandJSON")
+          .containsEntry("command", "DISPLAY")
+          .containsEntry("qualifier", "QUEUE")
+          .containsEntry("name", "Q1");
+      assertThat(payload).containsKey("parameters");
+      assertThat(payload).containsKey("responseParameters");
+    }
+
+    @Test
+    void buildCommandPayloadOmitsEmptyFields() {
+      Map<String, Object> payload =
+          MqRestSession.buildCommandPayload("ALTER", "QUEUE", null, Map.of(), List.of());
+
+      assertThat(payload).doesNotContainKey("name");
+      assertThat(payload).doesNotContainKey("parameters");
+      assertThat(payload).doesNotContainKey("responseParameters");
+    }
+
+    @Test
+    void buildCommandPayloadOmitsEmptyName() {
+      Map<String, Object> payload =
+          MqRestSession.buildCommandPayload("ALTER", "QUEUE", "", Map.of(), List.of());
+
+      assertThat(payload).doesNotContainKey("name");
+    }
+  }
+
+  @Nested
+  class WhereWithMapping {
+
+    @Test
+    void whereNotAddedWhenMappingDisabledAndBlank() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, "");
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      assertThat(payloadCaptor.getValue()).doesNotContainKey("parameters");
+    }
+
+    @Test
+    void whereAddedWithoutMappingWhenMappingDisabled() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, "MAXDEPTH GT 5000");
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      @SuppressWarnings("unchecked")
+      Map<String, Object> params = (Map<String, Object>) payloadCaptor.getValue().get("parameters");
+      assertThat((String) params.get("WHERE")).isEqualTo("MAXDEPTH GT 5000");
+    }
+  }
+
+  @Nested
+  class MissingCommandResponse {
+
+    @Test
+    void missingCommandResponseReturnsEmptyList() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse("{\"overallCompletionCode\":0,\"overallReasonCode\":0}"));
+
+      MqRestSession session = buildSessionNoMapping();
+      List<Map<String, Object>> result =
+          session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      assertThat(result).isEmpty();
+    }
+  }
+
+  @Nested
+  class TimeoutConfiguration {
+
+    @Test
+    void customTimeoutPassedToTransport() {
+      Duration customTimeout = Duration.ofSeconds(60);
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = basicBuilder().timeout(customTimeout).mapAttributes(false).build();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      ArgumentCaptor<Duration> timeoutCaptor = ArgumentCaptor.forClass(Duration.class);
+      verify(transport)
+          .postJson(anyString(), anyMap(), anyMap(), timeoutCaptor.capture(), anyBoolean());
+      assertThat(timeoutCaptor.getValue()).isEqualTo(customTimeout);
+    }
+
+    @Test
+    void nullTimeoutPassedToTransport() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = basicBuilder().timeout(null).mapAttributes(false).build();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      ArgumentCaptor<Duration> timeoutCaptor = ArgumentCaptor.forClass(Duration.class);
+      verify(transport)
+          .postJson(anyString(), anyMap(), anyMap(), timeoutCaptor.capture(), anyBoolean());
+      assertThat(timeoutCaptor.getValue()).isNull();
+    }
+  }
+
+  @Nested
+  class CommandNormalization {
+
+    @Test
+    void commandAndQualifierUppercased() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = buildSessionNoMapping();
+      session.mqscCommand("display", "queue", null, null, null, null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      assertThat(payloadCaptor.getValue())
+          .containsEntry("command", "DISPLAY")
+          .containsEntry("qualifier", "QUEUE");
+    }
+  }
+
+  @Nested
+  class MappingOverrides {
+
+    @Test
+    void mappingOverridesApplied() {
+      Map<String, Object> overrides = new LinkedHashMap<>();
+      Map<String, Object> qualifiers = new LinkedHashMap<>();
+      Map<String, Object> customQualifier = new LinkedHashMap<>();
+      customQualifier.put("request_key_map", Map.of("custom_attr", "CUSTOMATTR"));
+      customQualifier.put("response_key_map", Map.of("CUSTOMATTR", "custom_attr"));
+      qualifiers.put("custom", customQualifier);
+      overrides.put("qualifiers", qualifiers);
+      overrides.put("commands", Map.of("DISPLAY CUSTOM", Map.of("qualifier", "custom")));
+
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session =
+          basicBuilder()
+              .mappingOverrides(overrides)
+              .mappingOverridesMode(MappingOverrideMode.MERGE)
+              .mappingStrict(false)
+              .build();
+      session.mqscCommand("DISPLAY", "CUSTOM", "X1", Map.of("custom_attr", "val"), null, null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      @SuppressWarnings("unchecked")
+      Map<String, Object> params = (Map<String, Object>) payloadCaptor.getValue().get("parameters");
+      assertThat(params).containsKey("CUSTOMATTR");
+    }
+  }
+
+  @Nested
+  class VerifyTls {
+
+    @Test
+    void verifyTlsPassedToTransport() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = basicBuilder().verifyTls(false).mapAttributes(false).build();
+      session.mqscCommand("DISPLAY", "QUEUE", null, null, null, null);
+
+      ArgumentCaptor<Boolean> verifyCaptor = ArgumentCaptor.forClass(Boolean.class);
+      verify(transport).postJson(anyString(), anyMap(), anyMap(), any(), verifyCaptor.capture());
+      assertThat(verifyCaptor.getValue()).isFalse();
+    }
+  }
+
+  @Nested
+  class BranchCoverage {
+
+    @Test
+    void ltpaLoginWithNullCsrfTokenOmitsCsrfHeader() {
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(
+              successResponseWithHeaders("{}", Map.of("Set-Cookie", "LtpaToken2=tok; Path=/")));
+
+      new MqRestSession.Builder(BASE_URL, QMGR, new LtpaAuth("user", "pass"))
+          .transport(transport)
+          .csrfToken(null)
+          .build();
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), anyMap(), headersCaptor.capture(), any(), anyBoolean());
+      assertThat(headersCaptor.getValue()).doesNotContainKey("ibm-mq-rest-csrf-token");
+    }
+
+    @Test
+    void errorMessageIncludesCodesWhenOnlyCompletionCodePresent() {
+      Map<String, Object> payload = new LinkedHashMap<>();
+      payload.put("overallCompletionCode", 2.0);
+      payload.put("commandResponse", List.of());
+
+      assertThatThrownBy(() -> MqRestSession.raiseForCommandErrors(payload, 200))
+          .isInstanceOf(MqRestCommandException.class)
+          .hasMessageContaining("overallCompletionCode");
+    }
+
+    @Test
+    void errorMessageOmitsCodesWhenBothNull() {
+      Map<String, Object> payload = new LinkedHashMap<>();
+      payload.put("commandResponse", List.of(Map.of("completionCode", 2.0, "reasonCode", 3008.0)));
+
+      assertThatThrownBy(() -> MqRestSession.raiseForCommandErrors(payload, 200))
+          .isInstanceOf(MqRestCommandException.class);
+    }
+
+    @Test
+    void flattenSkipsNonMapNestedItems() {
+      Map<String, Object> item = new LinkedHashMap<>();
+      item.put("shared", "val");
+      item.put("objects", List.of("not_a_map", Map.of("key", "value")));
+
+      List<Map<String, Object>> result = MqRestSession.flattenNestedObjects(List.of(item));
+
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0)).containsEntry("shared", "val").containsEntry("key", "value");
+    }
+
+    @Test
+    void mapWhereKeywordKnownQualifierEmptyMapPermissivePassesThrough() {
+      // Qualifier exists but has no key maps → snakeToMqsc is empty but hasQualifier is true
+      // So the unknown qualifier branch is NOT taken, but keyword lookup returns null
+      Map<String, Object> overrides = new LinkedHashMap<>();
+      Map<String, Object> qualifiers = new LinkedHashMap<>();
+      qualifiers.put("emptyq", Map.of());
+      overrides.put("qualifiers", qualifiers);
+
+      MqRestSession session =
+          basicBuilder()
+              .mappingStrict(false)
+              .mappingOverrides(overrides)
+              .mappingOverridesMode(MappingOverrideMode.MERGE)
+              .build();
+
+      String result = session.mapWhereKeyword("some_key GT 100", "emptyq");
+
+      assertThat(result).isEqualTo("some_key GT 100");
+    }
+
+    @Test
+    void mapResponseParametersStrictThrowsForUnknownParam() {
+      // Use direct mqscCommand with a known qualifier but unknown response param
+      MqRestSession session = basicBuilder().mappingStrict(true).build();
+
+      assertThatThrownBy(
+              () ->
+                  session.mqscCommand(
+                      "DISPLAY", "QUEUE", "Q1", null, List.of("unknown_param"), null))
+          .isInstanceOf(MappingException.class);
+    }
+
+    @Test
+    void nullMappingOverridesHandledGracefully() {
+      MqRestSession session = basicBuilder().mappingOverrides(null).build();
+
+      assertThat(session).isNotNull();
+    }
+
+    @Test
+    void mapResponseParametersStrictWithAllKnownParamsSucceeds() {
+      // Known params should pass through strict mapping without issues
+      when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
+          .thenReturn(successResponse(emptyCommandResponse()));
+
+      MqRestSession session = basicBuilder().mappingStrict(true).build();
+      session.mqscCommand("DISPLAY", "QUEUE", "Q1", null, List.of("max_depth"), null);
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+      verify(transport)
+          .postJson(anyString(), payloadCaptor.capture(), anyMap(), any(), anyBoolean());
+      @SuppressWarnings("unchecked")
+      List<String> respParams = (List<String>) payloadCaptor.getValue().get("responseParameters");
+      assertThat(respParams).containsExactly("MAXDEPTH");
+    }
+
+    @Test
+    void errorDetectionOnlyReasonCodeNonNullInPayload() {
+      // overallCompletionCode null, overallReasonCode non-zero → should still show codes in message
+      Map<String, Object> payload = new LinkedHashMap<>();
+      payload.put("overallReasonCode", 3008.0);
+      payload.put("commandResponse", List.of());
+
+      assertThatThrownBy(() -> MqRestSession.raiseForCommandErrors(payload, 200))
+          .isInstanceOf(MqRestCommandException.class)
+          .hasMessageContaining("overallReasonCode");
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Implement `MqRestSession` class with Builder pattern — the central session class for the MQ REST administrative API (step 6 of tier 3 implementation sequence)
- Add `mqscCommand()` method with full pipeline: URL/header building, MQSC command dispatch, JSON response parsing, error detection, nested object flattening, and attribute mapping integration
- Add LTPA login at construction time for `LtpaAuth` credentials
- Add response parameter mapping and WHERE keyword mapping with strict/permissive modes
- Add session state tracking (`lastHttpStatus`, `lastResponseText`, `lastResponsePayload`, `lastCommandPayload`)
- Extend `MappingData` with `getResponseParameterMacros()` and `getSnakeToMqscMap()` public methods; make `hasQualifier()` public

## Test plan

- [x] 100 new tests covering: Builder validation, LTPA login, header building, mqscCommand flow, session state, response parsing, error detection, nested object flattening, attribute mapping integration, qualifier resolution, response parameter mapping, WHERE keyword mapping, static helpers, and MappingData additions
- [x] 280 total tests, all passing
- [x] 100% line and branch coverage (JaCoCo)
- [x] `./mvnw verify` passes full pipeline (Spotless, Checkstyle, compile, Surefire, JaCoCo, SpotBugs, PMD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)