### PR TITLE
feat: implement HttpClientTransport with JDK HttpClient

### DIFF
--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/HttpClientTransport.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/HttpClientTransport.java
@@ -1,0 +1,155 @@
+package io.github.wphillipmoore.mq.rest.admin;
+
+import com.google.gson.Gson;
+import io.github.wphillipmoore.mq.rest.admin.exception.MqRestTransportException;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.GeneralSecurityException;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * JDK {@link HttpClient}-based implementation of {@link MqRestTransport}.
+ *
+ * <p>Mirrors pymqrest's {@code RequestsTransport}. Uses {@link java.net.http.HttpClient} for HTTP
+ * communication and Gson for JSON serialization, requiring zero additional runtime dependencies
+ * beyond Gson.
+ */
+public final class HttpClientTransport implements MqRestTransport {
+
+  private final Gson gson = new Gson();
+  private final HttpClient client;
+  private HttpClient nonVerifyingClient;
+
+  /** Creates a transport with a default TLS-verifying {@link HttpClient}. */
+  public HttpClientTransport() {
+    this.client = HttpClient.newHttpClient();
+  }
+
+  /**
+   * Creates a transport with a custom {@link SSLContext} for mutual TLS.
+   *
+   * @param sslContext the SSL context to use
+   */
+  public HttpClientTransport(SSLContext sslContext) {
+    Objects.requireNonNull(sslContext, "sslContext");
+    this.client = HttpClient.newBuilder().sslContext(sslContext).build();
+  }
+
+  /**
+   * Creates a transport with an injected {@link HttpClient}. Package-private for testing.
+   *
+   * @param client the HTTP client to use
+   */
+  HttpClientTransport(HttpClient client) {
+    this.client = Objects.requireNonNull(client, "client");
+  }
+
+  @Override
+  public TransportResponse postJson(
+      String url,
+      Map<String, Object> payload,
+      Map<String, String> headers,
+      Duration timeout,
+      boolean verifyTls) {
+    HttpClient activeClient = verifyTls ? client : getNonVerifyingClient();
+    String json = gson.toJson(payload);
+
+    HttpRequest.Builder requestBuilder =
+        HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(json));
+
+    headers.forEach(requestBuilder::header);
+
+    if (timeout != null) {
+      requestBuilder.timeout(timeout);
+    }
+
+    HttpResponse<String> response;
+    try {
+      response = activeClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+    } catch (IOException e) {
+      throw new MqRestTransportException("HTTP request failed", url, e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new MqRestTransportException("HTTP request interrupted", url, e);
+    }
+
+    return new TransportResponse(
+        response.statusCode(), response.body(), flattenHeaders(response.headers()));
+  }
+
+  private synchronized HttpClient getNonVerifyingClient() {
+    if (nonVerifyingClient == null) {
+      SSLContext sslContext = createSslContext("TLS");
+      nonVerifyingClient = HttpClient.newBuilder().sslContext(sslContext).build();
+    }
+    return nonVerifyingClient;
+  }
+
+  /**
+   * Creates an {@link SSLContext} with a trust-all manager.
+   *
+   * @param protocol the SSL protocol name (e.g. "TLS")
+   * @return an initialized SSLContext that trusts all certificates
+   * @throws IllegalStateException if the protocol is not available
+   */
+  static SSLContext createSslContext(String protocol) {
+    try {
+      SSLContext sslContext = SSLContext.getInstance(protocol);
+      sslContext.init(null, new TrustManager[] {new TrustAllManager()}, null);
+      return sslContext;
+    } catch (GeneralSecurityException e) {
+      throw new IllegalStateException("Failed to create SSLContext", e);
+    }
+  }
+
+  /**
+   * Flattens {@link HttpHeaders} multi-value map to single-value map per RFC 9110 section 5.3.
+   *
+   * <p>Multiple values for the same header name are joined with {@code ", "}.
+   *
+   * @param httpHeaders the HTTP response headers
+   * @return a flattened string-to-string header map
+   */
+  static Map<String, String> flattenHeaders(HttpHeaders httpHeaders) {
+    Map<String, String> result = new LinkedHashMap<>();
+    httpHeaders.map().forEach((name, values) -> result.put(name, String.join(", ", values)));
+    return result;
+  }
+
+  /**
+   * An {@link X509TrustManager} that accepts all certificates. Used when TLS verification is
+   * disabled.
+   */
+  @SuppressWarnings("all")
+  static final class TrustAllManager implements X509TrustManager {
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType) {
+      // Accept all client certificates
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType) {
+      // Accept all server certificates
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+      return new X509Certificate[0];
+    }
+  }
+}

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/HttpClientTransportTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/HttpClientTransportTest.java
@@ -1,0 +1,384 @@
+package io.github.wphillipmoore.mq.rest.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.sun.net.httpserver.HttpServer;
+import io.github.wphillipmoore.mq.rest.admin.exception.MqRestTransportException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.net.ssl.SSLContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class HttpClientTransportTest {
+
+  private HttpServer server;
+  private String baseUrl;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server = HttpServer.create(new InetSocketAddress(0), 0);
+    int port = server.getAddress().getPort();
+    baseUrl = "http://localhost:" + port;
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  private void startServer(int statusCode, String responseBody) {
+    startServer(statusCode, responseBody, Map.of());
+  }
+
+  private void startServer(
+      int statusCode, String responseBody, Map<String, String> responseHeaders) {
+    server.createContext(
+        "/",
+        exchange -> {
+          responseHeaders.forEach((k, v) -> exchange.getResponseHeaders().add(k, v));
+          byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+          exchange.sendResponseHeaders(statusCode, body.length);
+          try (OutputStream os = exchange.getResponseBody()) {
+            os.write(body);
+          }
+        });
+    server.start();
+  }
+
+  @Nested
+  class PostJsonHappyPath {
+
+    @Test
+    void sendsJsonBodyWithContentTypeHeader() throws IOException {
+      final String[] capturedBody = {null};
+      final String[] capturedContentType = {null};
+      server.createContext(
+          "/",
+          exchange -> {
+            capturedContentType[0] = exchange.getRequestHeaders().getFirst("Content-type");
+            capturedBody[0] = new String(exchange.getRequestBody().readAllBytes());
+            exchange.sendResponseHeaders(200, 0);
+            exchange.getResponseBody().close();
+          });
+      server.start();
+
+      HttpClientTransport transport = new HttpClientTransport();
+      transport.postJson(baseUrl + "/test", Map.of("key", "value"), Map.of(), null, true);
+
+      assertThat(capturedContentType[0]).isEqualTo("application/json");
+      assertThat(capturedBody[0]).isEqualTo("{\"key\":\"value\"}");
+    }
+
+    @Test
+    void forwardsCallerHeaders() throws IOException {
+      final String[] capturedHeader = {null};
+      server.createContext(
+          "/",
+          exchange -> {
+            capturedHeader[0] = exchange.getRequestHeaders().getFirst("X-Custom");
+            exchange.sendResponseHeaders(200, 0);
+            exchange.getResponseBody().close();
+          });
+      server.start();
+
+      HttpClientTransport transport = new HttpClientTransport();
+      transport.postJson(
+          baseUrl + "/test", Map.of(), Map.of("X-Custom", "custom-value"), null, true);
+
+      assertThat(capturedHeader[0]).isEqualTo("custom-value");
+    }
+
+    @Test
+    void returnsResponseStatusCode() {
+      startServer(201, "{}");
+
+      HttpClientTransport transport = new HttpClientTransport();
+      TransportResponse response =
+          transport.postJson(baseUrl + "/test", Map.of(), Map.of(), null, true);
+
+      assertThat(response.statusCode()).isEqualTo(201);
+    }
+
+    @Test
+    void returnsResponseBody() {
+      startServer(200, "{\"result\":\"ok\"}");
+
+      HttpClientTransport transport = new HttpClientTransport();
+      TransportResponse response =
+          transport.postJson(baseUrl + "/test", Map.of(), Map.of(), null, true);
+
+      assertThat(response.body()).isEqualTo("{\"result\":\"ok\"}");
+    }
+
+    @Test
+    void returnsResponseHeaders() {
+      startServer(200, "{}", Map.of("X-Response", "resp-value"));
+
+      HttpClientTransport transport = new HttpClientTransport();
+      TransportResponse response =
+          transport.postJson(baseUrl + "/test", Map.of(), Map.of(), null, true);
+
+      assertThat(response.headers()).containsEntry("x-response", "resp-value");
+    }
+
+    @Test
+    void acceptsNullTimeout() {
+      startServer(200, "{}");
+
+      HttpClientTransport transport = new HttpClientTransport();
+      TransportResponse response =
+          transport.postJson(baseUrl + "/test", Map.of(), Map.of(), null, true);
+
+      assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    void appliesNonNullTimeout() {
+      startServer(200, "{}");
+
+      HttpClientTransport transport = new HttpClientTransport();
+      TransportResponse response =
+          transport.postJson(baseUrl + "/test", Map.of(), Map.of(), Duration.ofSeconds(30), true);
+
+      assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    void reusesSameTransportInstance() {
+      startServer(200, "{}");
+
+      HttpClientTransport transport = new HttpClientTransport();
+      TransportResponse first =
+          transport.postJson(baseUrl + "/test", Map.of(), Map.of(), null, true);
+      TransportResponse second =
+          transport.postJson(baseUrl + "/test", Map.of(), Map.of(), null, true);
+
+      assertThat(first.statusCode()).isEqualTo(200);
+      assertThat(second.statusCode()).isEqualTo(200);
+    }
+  }
+
+  @Nested
+  class VerifyTlsBranching {
+
+    @Test
+    void verifyTlsTrueUsesPrimaryClient() {
+      startServer(200, "{\"tls\":\"verified\"}");
+
+      HttpClientTransport transport = new HttpClientTransport();
+      TransportResponse response =
+          transport.postJson(baseUrl + "/test", Map.of(), Map.of(), null, true);
+
+      assertThat(response.body()).isEqualTo("{\"tls\":\"verified\"}");
+    }
+
+    @Test
+    void verifyTlsFalseUsesNonVerifyingClient() {
+      startServer(200, "{\"tls\":\"unverified\"}");
+
+      HttpClientTransport transport = new HttpClientTransport();
+      TransportResponse response =
+          transport.postJson(baseUrl + "/test", Map.of(), Map.of(), null, false);
+
+      assertThat(response.body()).isEqualTo("{\"tls\":\"unverified\"}");
+    }
+
+    @Test
+    void nonVerifyingClientIsLazilyCreatedAndReused() {
+      startServer(200, "{}");
+
+      HttpClientTransport transport = new HttpClientTransport();
+      TransportResponse first =
+          transport.postJson(baseUrl + "/test", Map.of(), Map.of(), null, false);
+      TransportResponse second =
+          transport.postJson(baseUrl + "/test", Map.of(), Map.of(), null, false);
+
+      assertThat(first.statusCode()).isEqualTo(200);
+      assertThat(second.statusCode()).isEqualTo(200);
+    }
+  }
+
+  @Nested
+  class ExceptionHandling {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void wrapsIoExceptionInTransportException() throws IOException, InterruptedException {
+      HttpClient mockClient = mock(HttpClient.class);
+      when(mockClient.send(any(), any(HttpResponse.BodyHandler.class)))
+          .thenThrow(new IOException("connection reset"));
+
+      HttpClientTransport transport = new HttpClientTransport(mockClient);
+
+      assertThatThrownBy(
+              () -> transport.postJson("http://localhost/test", Map.of(), Map.of(), null, true))
+          .isInstanceOf(MqRestTransportException.class)
+          .hasMessageContaining("HTTP request failed")
+          .hasCauseInstanceOf(IOException.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void wrapsInterruptedExceptionAndResetsFlag() throws IOException, InterruptedException {
+      HttpClient mockClient = mock(HttpClient.class);
+      when(mockClient.send(any(), any(HttpResponse.BodyHandler.class)))
+          .thenThrow(new InterruptedException("interrupted"));
+
+      HttpClientTransport transport = new HttpClientTransport(mockClient);
+
+      assertThatThrownBy(
+              () -> transport.postJson("http://localhost/test", Map.of(), Map.of(), null, true))
+          .isInstanceOf(MqRestTransportException.class)
+          .hasMessageContaining("HTTP request interrupted")
+          .hasCauseInstanceOf(InterruptedException.class);
+
+      assertThat(Thread.currentThread().isInterrupted()).isTrue();
+      // Clear the interrupt flag for test cleanup
+      Thread.interrupted();
+    }
+
+    @Test
+    void connectionRefusedWrappedInTransportException() {
+      HttpClientTransport transport = new HttpClientTransport();
+
+      assertThatThrownBy(
+              () ->
+                  transport.postJson(
+                      "http://localhost:1/unreachable", Map.of(), Map.of(), null, true))
+          .isInstanceOf(MqRestTransportException.class)
+          .hasMessageContaining("HTTP request failed")
+          .hasCauseInstanceOf(IOException.class);
+    }
+  }
+
+  @Nested
+  class FlattenHeadersTest {
+
+    @Test
+    void flattensSingleValueHeaders() {
+      Map<String, List<String>> map = new LinkedHashMap<>();
+      map.put("Content-Type", List.of("application/json"));
+      HttpHeaders headers = HttpHeaders.of(map, (k, v) -> true);
+
+      Map<String, String> result = HttpClientTransport.flattenHeaders(headers);
+
+      assertThat(result).containsEntry("Content-Type", "application/json");
+    }
+
+    @Test
+    void joinsMultiValueHeadersWithCommaSpace() {
+      Map<String, List<String>> map = new LinkedHashMap<>();
+      map.put("Accept", List.of("text/html", "application/json"));
+      HttpHeaders headers = HttpHeaders.of(map, (k, v) -> true);
+
+      Map<String, String> result = HttpClientTransport.flattenHeaders(headers);
+
+      assertThat(result).containsEntry("Accept", "text/html, application/json");
+    }
+
+    @Test
+    void handlesEmptyHeaders() {
+      HttpHeaders headers = HttpHeaders.of(Map.of(), (k, v) -> true);
+
+      Map<String, String> result = HttpClientTransport.flattenHeaders(headers);
+
+      assertThat(result).isEmpty();
+    }
+  }
+
+  @Nested
+  class CreateSslContextTest {
+
+    @Test
+    void succeedsWithTlsProtocol() {
+      SSLContext context = HttpClientTransport.createSslContext("TLS");
+
+      assertThat(context).isNotNull();
+      assertThat(context.getProtocol()).isEqualTo("TLS");
+    }
+
+    @Test
+    void throwsIllegalStateExceptionForInvalidProtocol() {
+      assertThatThrownBy(() -> HttpClientTransport.createSslContext("INVALID"))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Failed to create SSLContext");
+    }
+  }
+
+  @Nested
+  class TrustAllManagerTest {
+
+    @Test
+    void getAcceptedIssuersReturnsEmptyArray() {
+      HttpClientTransport.TrustAllManager manager = new HttpClientTransport.TrustAllManager();
+
+      assertThat(manager.getAcceptedIssuers()).isEmpty();
+    }
+
+    @Test
+    void checkClientTrustedDoesNotThrow() {
+      HttpClientTransport.TrustAllManager manager = new HttpClientTransport.TrustAllManager();
+
+      manager.checkClientTrusted(null, null);
+    }
+
+    @Test
+    void checkServerTrustedDoesNotThrow() {
+      HttpClientTransport.TrustAllManager manager = new HttpClientTransport.TrustAllManager();
+
+      manager.checkServerTrusted(null, null);
+    }
+  }
+
+  @Nested
+  class ConstructorTest {
+
+    @Test
+    void noArgConstructorCreatesWorkingTransport() {
+      startServer(200, "{}");
+
+      HttpClientTransport transport = new HttpClientTransport();
+      TransportResponse response =
+          transport.postJson(baseUrl + "/test", Map.of(), Map.of(), null, true);
+
+      assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    void sslContextConstructorAccepted() throws Exception {
+      startServer(200, "{}");
+
+      SSLContext sslContext = SSLContext.getDefault();
+      HttpClientTransport transport = new HttpClientTransport(sslContext);
+      TransportResponse response =
+          transport.postJson(baseUrl + "/test", Map.of(), Map.of(), null, true);
+
+      assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    void nullSslContextThrowsNullPointerException() {
+      assertThatThrownBy(() -> new HttpClientTransport((SSLContext) null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("sslContext");
+    }
+  }
+}


### PR DESCRIPTION
Closes #20

## Summary

- Implements `HttpClientTransport`, the real JDK `HttpClient`-based implementation of `MqRestTransport` (Step 10, final tier 3 step)
- Supports TLS verification toggle with lazy non-verifying client creation, custom `SSLContext` for mTLS, timeout propagation, and RFC 9110 header flattening
- Zero additional runtime dependencies beyond Gson — uses `java.net.http.HttpClient` from the JDK
- 25 unit tests covering happy path, exception handling, TLS branching, static helpers, TrustAllManager, and constructors with 100% line and branch coverage
- Fixed co-author trailer to use approved identity (`wphillipmoore-claude`)

## Test plan

- [x] `./mvnw verify` passes (Spotless, Checkstyle, compile, Surefire, JaCoCo 100%, SpotBugs, PMD)
- [x] 25 new tests in `HttpClientTransportTest` all pass
- [x] All 616 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)