### PR TITLE
feat: add git hooks for branch, commit message, and co-author validation

### DIFF
--- a/docs/plans/open-decisions.md
+++ b/docs/plans/open-decisions.md
@@ -94,5 +94,5 @@ Java port of pymqrest.
 - **Local validation command**: `./mvnw verify` (decided 2026-02-12, see
   `docs/plans/2026-02-12-tier2-decisions.md`).
 - **Docs-only validation**: TBD (markdownlint is already available).
-- **Git hooks**: TBD (scripts/git-hooks directory created, hooks not yet
-  written).
+- **Git hooks**: `pre-commit` (branch protection + naming) and `commit-msg`
+  (Conventional Commits + co-author validation) (decided 2026-02-13).

--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit_message_file="${1:-}"
+
+if [[ -z "$commit_message_file" ]]; then
+  echo "ERROR: commit message file path is required." >&2
+  exit 2
+fi
+
+hook_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$hook_dir/../.." && pwd)"
+
+"$repo_root/scripts/lint/commit-message.sh" "$commit_message_file"
+"$repo_root/scripts/lint/co-author.sh" "$commit_message_file"

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [[ -z "$current_branch" || "$current_branch" == "HEAD" ]]; then
+  echo "ERROR: unable to determine the current branch. Create a feature branch before committing." >&2
+  exit 1
+fi
+
+case "$current_branch" in
+  develop|main|release/*)
+    echo "ERROR: direct commits to protected branches are forbidden ($current_branch)." >&2
+    echo "Create a short-lived branch (feature/*, bugfix/*, hotfix/*) and open a PR." >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! "$current_branch" =~ ^(feature|bugfix|hotfix)/.+$ ]]; then
+  echo "ERROR: branch '$current_branch' does not follow the required prefix rules." >&2
+  echo "Allowed prefixes: feature/*, bugfix/*, hotfix/*" >&2
+  exit 1
+fi

--- a/scripts/lint/co-author.sh
+++ b/scripts/lint/co-author.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit_message_file="${1:-}"
+
+if [[ -z "$commit_message_file" || ! -f "$commit_message_file" ]]; then
+  echo "ERROR: commit message file path is required." >&2
+  exit 2
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+standards_file="$repo_root/docs/repository-standards.md"
+
+if [[ ! -f "$standards_file" ]]; then
+  echo "ERROR: repository standards file not found at $standards_file" >&2
+  exit 2
+fi
+
+# Extract Co-Authored-By trailers from the commit message (name <email> portion).
+commit_trailers=()
+while IFS= read -r line; do
+  # Strip "Co-Authored-By: " prefix to get "name <email>"
+  identity="${line#*Co-Authored-By: }"
+  commit_trailers+=("$identity")
+done < <(grep -i '^Co-Authored-By:' "$commit_message_file" || true)
+
+# No trailers means no AI contribution — that's fine.
+if [[ ${#commit_trailers[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+# Extract approved identities from repository-standards.md.
+# Lines look like: "- Co-Authored-By: name <email>"
+approved_identities=()
+while IFS= read -r line; do
+  identity="${line#*Co-Authored-By: }"
+  approved_identities+=("$identity")
+done < <(grep -E '^\- Co-Authored-By:' "$standards_file" || true)
+
+if [[ ${#approved_identities[@]} -eq 0 ]]; then
+  echo "ERROR: no approved Co-Authored-By identities found in $standards_file" >&2
+  exit 2
+fi
+
+# Validate each commit trailer against the approved list.
+failed=0
+for trailer in "${commit_trailers[@]}"; do
+  match=0
+  for approved in "${approved_identities[@]}"; do
+    if [[ "$trailer" == "$approved" ]]; then
+      match=1
+      break
+    fi
+  done
+  if [[ $match -eq 0 ]]; then
+    echo "ERROR: unapproved Co-Authored-By trailer:" >&2
+    echo "  Co-Authored-By: $trailer" >&2
+    failed=1
+  fi
+done
+
+if [[ $failed -ne 0 ]]; then
+  echo "" >&2
+  echo "Approved identities (from docs/repository-standards.md):" >&2
+  for approved in "${approved_identities[@]}"; do
+    echo "  Co-Authored-By: $approved" >&2
+  done
+  exit 1
+fi

--- a/scripts/lint/commit-message.sh
+++ b/scripts/lint/commit-message.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit_message_file="${1:-}"
+
+if [[ -z "$commit_message_file" || ! -f "$commit_message_file" ]]; then
+  echo "ERROR: commit message file path is required." >&2
+  exit 2
+fi
+
+subject_line="$(head -n 1 "$commit_message_file")"
+
+conventional_regex='^(feat|fix|docs|style|refactor|test|chore)(\([^\)]+\))?: .+'
+
+if [[ ! "$subject_line" =~ $conventional_regex ]]; then
+  echo "ERROR: commit message does not follow Conventional Commits." >&2
+  echo "Expected: <type>(optional-scope): <description>" >&2
+  echo "Allowed types: feat, fix, docs, style, refactor, test, chore" >&2
+  echo "Got: $subject_line" >&2
+  exit 1
+fi


### PR DESCRIPTION
Closes #22

## Summary

- Ports `pre-commit` hook from pymqrest: blocks commits to protected branches (`develop`, `main`, `release/*`) and enforces `feature/*`, `bugfix/*`, `hotfix/*` naming
- Ports `commit-msg` hook with `commit-message.sh` lint script: validates Conventional Commits format
- Adds new `co-author.sh` lint script: validates Co-Authored-By trailers against the approved identity list in `docs/repository-standards.md`
- Marks git hooks decision as decided in `docs/plans/open-decisions.md`

## Test plan

- [x] `pre-commit` allows commits on `feature/*` branch
- [x] `commit-message.sh` rejects non-Conventional Commits format
- [x] `commit-message.sh` accepts valid Conventional Commits format
- [x] `co-author.sh` rejects unapproved Co-Authored-By trailers
- [x] `co-author.sh` accepts approved Co-Authored-By trailers
- [x] `co-author.sh` passes when no Co-Authored-By trailer is present
- [x] End-to-end: `git commit` with bad message fails
- [x] End-to-end: `git commit` with bad co-author fails
- [x] End-to-end: `git commit` with valid message and approved co-author succeeds
- [x] `./mvnw verify` passes (BUILD SUCCESS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)