### PR TITLE
feat: populate mapping-data.json with full MQ attribute set

### DIFF
--- a/src/main/resources/io/github/wphillipmoore/mq/rest/admin/mapping/mapping-data.json
+++ b/src/main/resources/io/github/wphillipmoore/mq/rest/admin/mapping/mapping-data.json
@@ -1,43 +1,2502 @@
 {
   "commands": {
-    "DISPLAY QUEUE": {
+    "ALTER AUTHINFO": {
+      "qualifier": "authinfo"
+    },
+    "ALTER BUFFPOOL": {
+      "qualifier": "buffpool"
+    },
+    "ALTER CFSTRUCT": {
+      "qualifier": "cfstruct"
+    },
+    "ALTER CHANNEL": {
+      "qualifier": "channel"
+    },
+    "ALTER COMMINFO": {
+      "qualifier": "comminfo"
+    },
+    "ALTER LISTENER": {
+      "qualifier": "listener"
+    },
+    "ALTER NAMELIST": {
+      "qualifier": "namelist"
+    },
+    "ALTER PROCESS": {
+      "qualifier": "process"
+    },
+    "ALTER PSID": {
+      "qualifier": "psid"
+    },
+    "ALTER QMGR": {
+      "qualifier": "qmgr"
+    },
+    "ALTER SECURITY": {
+      "qualifier": "security"
+    },
+    "ALTER SERVICE": {
+      "qualifier": "service"
+    },
+    "ALTER SMDS": {
+      "qualifier": "smds"
+    },
+    "ALTER STGCLASS": {
+      "qualifier": "stgclass"
+    },
+    "ALTER SUB": {
+      "qualifier": "sub"
+    },
+    "ALTER TOPIC": {
+      "qualifier": "topic"
+    },
+    "ALTER TRACE": {
+      "qualifier": "trace"
+    },
+    "ARCHIVE LOG": {
+      "qualifier": "log"
+    },
+    "BACKUP CFSTRUCT": {
+      "qualifier": "cfstruct"
+    },
+    "CLEAR QLOCAL": {
       "qualifier": "queue"
+    },
+    "CLEAR TOPICSTR": {
+      "qualifier": "topicstr"
+    },
+    "DEFINE AUTHINFO": {
+      "qualifier": "authinfo"
+    },
+    "DEFINE BUFFPOOL": {
+      "qualifier": "buffpool"
+    },
+    "DEFINE CFSTRUCT": {
+      "qualifier": "cfstruct"
+    },
+    "DEFINE CHANNEL": {
+      "qualifier": "channel"
+    },
+    "DEFINE COMMINFO": {
+      "qualifier": "comminfo"
+    },
+    "DEFINE LISTENER": {
+      "qualifier": "listener"
+    },
+    "DEFINE LOG": {
+      "qualifier": "log"
+    },
+    "DEFINE MAXSMSGS": {
+      "qualifier": "maxsmsgs"
+    },
+    "DEFINE NAMELIST": {
+      "qualifier": "namelist"
+    },
+    "DEFINE PROCESS": {
+      "qualifier": "process"
+    },
+    "DEFINE PSID": {
+      "qualifier": "psid"
+    },
+    "DEFINE SERVICE": {
+      "qualifier": "service"
+    },
+    "DEFINE STGCLASS": {
+      "qualifier": "stgclass"
+    },
+    "DEFINE SUB": {
+      "qualifier": "sub"
+    },
+    "DEFINE TOPIC": {
+      "qualifier": "topic"
+    },
+    "DELETE AUTHINFO": {
+      "qualifier": "authinfo"
+    },
+    "DELETE AUTHREC": {
+      "qualifier": "authrec"
+    },
+    "DELETE BUFFPOOL": {
+      "qualifier": "buffpool"
+    },
+    "DELETE CFSTRUCT": {
+      "qualifier": "cfstruct"
+    },
+    "DELETE CHANNEL": {
+      "qualifier": "channel"
+    },
+    "DELETE COMMINFO": {
+      "qualifier": "comminfo"
+    },
+    "DELETE LISTENER": {
+      "qualifier": "listener"
+    },
+    "DELETE NAMELIST": {
+      "qualifier": "namelist"
+    },
+    "DELETE POLICY": {
+      "qualifier": "policy"
+    },
+    "DELETE PROCESS": {
+      "qualifier": "process"
+    },
+    "DELETE PSID": {
+      "qualifier": "psid"
+    },
+    "DELETE SERVICE": {
+      "qualifier": "service"
+    },
+    "DELETE STGCLASS": {
+      "qualifier": "stgclass"
+    },
+    "DELETE SUB": {
+      "qualifier": "sub"
+    },
+    "DELETE TOPIC": {
+      "qualifier": "topic"
+    },
+    "DISPLAY APSTATUS": {
+      "qualifier": "apstatus"
+    },
+    "DISPLAY ARCHIVE": {
+      "qualifier": "archive"
+    },
+    "DISPLAY AUTHINFO": {
+      "qualifier": "authinfo"
+    },
+    "DISPLAY AUTHREC": {
+      "qualifier": "authrec",
+      "response_parameter_macros": [
+        "AUTHLIST",
+        "ENTITY",
+        "ENTTYPE"
+      ]
+    },
+    "DISPLAY AUTHSERV": {
+      "qualifier": "authserv"
+    },
+    "DISPLAY CFSTATUS": {
+      "qualifier": "cfstatus"
+    },
+    "DISPLAY CFSTRUCT": {
+      "qualifier": "cfstruct"
+    },
+    "DISPLAY CHANNEL": {
+      "qualifier": "channel"
+    },
+    "DISPLAY CHINIT": {
+      "qualifier": "chinit"
+    },
+    "DISPLAY CHLAUTH": {
+      "qualifier": "chlauth"
+    },
+    "DISPLAY CHSTATUS": {
+      "qualifier": "chstatus"
+    },
+    "DISPLAY CLUSQMGR": {
+      "qualifier": "clusqmgr"
+    },
+    "DISPLAY CMDSERV": {
+      "qualifier": "cmdserv"
+    },
+    "DISPLAY COMMINFO": {
+      "qualifier": "comminfo"
+    },
+    "DISPLAY CONN": {
+      "qualifier": "conn"
+    },
+    "DISPLAY ENTAUTH": {
+      "qualifier": "entauth",
+      "response_parameter_macros": [
+        "AUTHLIST",
+        "ENTITY",
+        "ENTTYPE",
+        "OBJTYPE"
+      ]
+    },
+    "DISPLAY GROUP": {
+      "qualifier": "group"
+    },
+    "DISPLAY LISTENER": {
+      "qualifier": "listener"
+    },
+    "DISPLAY LOG": {
+      "qualifier": "log"
+    },
+    "DISPLAY LSSTATUS": {
+      "qualifier": "lsstatus"
+    },
+    "DISPLAY MAXSMSGS": {
+      "qualifier": "maxsmsgs"
+    },
+    "DISPLAY NAMELIST": {
+      "qualifier": "namelist"
+    },
+    "DISPLAY POLICY": {
+      "qualifier": "policy"
+    },
+    "DISPLAY PROCESS": {
+      "qualifier": "process"
+    },
+    "DISPLAY PUBSUB": {
+      "qualifier": "pubsub"
+    },
+    "DISPLAY QMGR": {
+      "qualifier": "qmgr",
+      "response_parameter_macros": [
+        "CHINIT",
+        "CLUSTER",
+        "EVENT",
+        "PUBSUB",
+        "SYSTEM"
+      ]
+    },
+    "DISPLAY QMSTATUS": {
+      "qualifier": "qmstatus",
+      "response_parameter_macros": [
+        "LOG"
+      ]
+    },
+    "DISPLAY QSTATUS": {
+      "qualifier": "qstatus",
+      "response_parameter_macros": [
+        "MONITOR"
+      ]
+    },
+    "DISPLAY QUEUE": {
+      "qualifier": "queue",
+      "response_parameter_macros": [
+        "CLUSINFO"
+      ]
+    },
+    "DISPLAY SBSTATUS": {
+      "qualifier": "sbstatus"
+    },
+    "DISPLAY SECURITY": {
+      "qualifier": "security"
+    },
+    "DISPLAY SERVICE": {
+      "qualifier": "service"
+    },
+    "DISPLAY SMDS": {
+      "qualifier": "smds"
+    },
+    "DISPLAY SMDSCONN": {
+      "qualifier": "smdsconn"
+    },
+    "DISPLAY STGCLASS": {
+      "qualifier": "stgclass"
+    },
+    "DISPLAY SUB": {
+      "qualifier": "sub",
+      "response_parameter_macros": [
+        "SUMMARY"
+      ]
+    },
+    "DISPLAY SYSTEM": {
+      "qualifier": "system"
+    },
+    "DISPLAY SVSTATUS": {
+      "qualifier": "svstatus"
+    },
+    "DISPLAY TCLUSTER": {
+      "qualifier": "tcluster"
+    },
+    "DISPLAY THREAD": {
+      "qualifier": "thread"
+    },
+    "DISPLAY TOPIC": {
+      "qualifier": "topic"
+    },
+    "DISPLAY TPSTATUS": {
+      "qualifier": "tpstatus"
+    },
+    "DISPLAY TRACE": {
+      "qualifier": "trace"
+    },
+    "DISPLAY USAGE": {
+      "qualifier": "usage"
+    },
+    "MOVE QLOCAL": {
+      "qualifier": "queue"
+    },
+    "PING CHANNEL": {
+      "qualifier": "channel"
+    },
+    "PING QMGR": {
+      "qualifier": "qmgr"
+    },
+    "PURGE CHANNEL": {
+      "qualifier": "channel"
+    },
+    "RECOVER BSDS": {
+      "qualifier": "bsds"
+    },
+    "RECOVER CFSTRUCT": {
+      "qualifier": "cfstruct"
+    },
+    "REFRESH CLUSTER": {
+      "qualifier": "cluster"
+    },
+    "REFRESH QMGR": {
+      "qualifier": "qmgr"
+    },
+    "REFRESH SECURITY": {
+      "qualifier": "security"
+    },
+    "RESET CFSTRUCT": {
+      "qualifier": "cfstruct"
+    },
+    "RESET CHANNEL": {
+      "qualifier": "channel"
+    },
+    "RESET CLUSTER": {
+      "qualifier": "cluster"
+    },
+    "RESET QMGR": {
+      "qualifier": "qmgr"
+    },
+    "RESET QSTATS": {
+      "qualifier": "queue"
+    },
+    "RESET SMDS": {
+      "qualifier": "smds"
+    },
+    "RESET TPIPE": {
+      "qualifier": "tpipe"
+    },
+    "RESOLVE CHANNEL": {
+      "qualifier": "channel"
+    },
+    "RESOLVE INDOUBT": {
+      "qualifier": "indoubt"
+    },
+    "RESUME QMGR": {
+      "qualifier": "qmgr"
+    },
+    "RVERIFY SECURITY": {
+      "qualifier": "security"
+    },
+    "SET ARCHIVE": {
+      "qualifier": "archive"
+    },
+    "SET AUTHREC": {
+      "qualifier": "authrec"
+    },
+    "SET CHLAUTH": {
+      "qualifier": "chlauth"
+    },
+    "SET LOG": {
+      "qualifier": "log"
+    },
+    "SET POLICY": {
+      "qualifier": "policy"
+    },
+    "SET SYSTEM": {
+      "qualifier": "system"
+    },
+    "START CHANNEL": {
+      "qualifier": "channel"
+    },
+    "START CHINIT": {
+      "qualifier": "chinit"
+    },
+    "START CMDSERV": {
+      "qualifier": "cmdserv"
+    },
+    "START LISTENER": {
+      "qualifier": "listener"
+    },
+    "START QMGR": {
+      "qualifier": "qmgr"
+    },
+    "START SERVICE": {
+      "qualifier": "service"
+    },
+    "START SMDSCONN": {
+      "qualifier": "smdsconn"
+    },
+    "START TRACE": {
+      "qualifier": "trace"
+    },
+    "STOP CHANNEL": {
+      "qualifier": "channel"
+    },
+    "STOP CHINIT": {
+      "qualifier": "chinit"
+    },
+    "STOP CMDSERV": {
+      "qualifier": "cmdserv"
+    },
+    "STOP CONN": {
+      "qualifier": "conn"
+    },
+    "STOP LISTENER": {
+      "qualifier": "listener"
+    },
+    "STOP QMGR": {
+      "qualifier": "qmgr"
+    },
+    "STOP SERVICE": {
+      "qualifier": "service"
+    },
+    "STOP SMDSCONN": {
+      "qualifier": "smdsconn"
+    },
+    "STOP TRACE": {
+      "qualifier": "trace"
+    },
+    "SUSPEND QMGR": {
+      "qualifier": "qmgr"
     }
   },
   "qualifiers": {
-    "queue": {
-      "request_key_map": {
-        "max_depth": "MAXDEPTH",
-        "description": "DESCR"
+    "apstatus": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {
+        "ACTIVE": "queue_manager_active",
+        "BALANCED": "balanced",
+        "BALOPTS": "balancing_options",
+        "BALSTATE": "balance_state",
+        "BALTMOUT": "timeout",
+        "BALTYPE": "application_type",
+        "CLUSTER": "cluster_name",
+        "CONNS": "connections",
+        "CONNTAG": "connection_tag",
+        "COUNT": "instance_count",
+        "IMMCOUNT": "immovable_count",
+        "IMMDATE": "immovable_date",
+        "IMMREASN": "immovable_reason",
+        "IMMTIME": "immovable_time",
+        "LMSGDATE": "last_message_date",
+        "LMSGTIME": "last_message_time",
+        "MOVABLE": "movable",
+        "MOVCOUNT": "movable_instance_count",
+        "QMID": "queue_manager_id",
+        "QMNAME": "queue_manager_name"
       },
-      "request_value_map": {
-        "get": {
-          "enabled": "ENABLED",
-          "disabled": "DISABLED"
-        }
+      "response_value_map": {}
+    },
+    "archive": {
+      "request_key_map": {
+        "allocation_primary": "PRIQTY",
+        "allocation_secondary": "SECQTY",
+        "allocation_units": "ALCUNIT",
+        "archive_prefix1": "ARCPFX1",
+        "archive_prefix2": "ARCPFX2",
+        "archive_retention": "ARCRETN",
+        "archive_unit2": "UNIT2",
+        "archive_wait_for_reply": "ARCWTOR",
+        "block_size": "BLKSIZE",
+        "catalog": "CATALOG",
+        "command_scope": "CMDSCOPE",
+        "compact": "COMPACT",
+        "protect": "PROTECT",
+        "quiesce_interval": "QUIESCE",
+        "archive_routing_code": "ARCWRTC",
+        "time_stamp_format": "TSTAMP"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "authinfo": {
+      "request_key_map": {
+        "adopt_context": "ADOPTCTX",
+        "authentication_info_type": "AUTHTYPE",
+        "authentication_method": "AUTHENMD",
+        "authorization_method": "AUTHORMD",
+        "base_dn_group": "BASEDNG",
+        "base_dn_user": "BASEDNU",
+        "check_client": "CHCKCLNT",
+        "check_local": "CHCKLOCL",
+        "class_group": "CLASSGRP",
+        "class_user": "CLASSUSR",
+        "command_scope": "CMDSCOPE",
+        "connection_name": "CONNAME",
+        "description": "DESCR",
+        "failure_delay": "FAILDLAY",
+        "find_group": "FINDGRP",
+        "group_field": "GRPFIELD",
+        "group_nesting": "NESTGRP",
+        "ignore_state": "IGNSTATE",
+        "ldap_password": "LDAPPWD",
+        "ldap_user_name": "LDAPUSER",
+        "like": "LIKE",
+        "ocsp_responder_url": "OCSPURL",
+        "queue_sharing_group_disposition": "QSGDISP",
+        "secure_communications": "SECCOMM",
+        "short_user": "SHORTUSR",
+        "user_field": "USRFIELD"
       },
       "request_key_value_map": {
-        "purge": {
+        "noreplace": {
           "yes": {
-            "key": "PURGE",
-            "value": "YES"
-          },
-          "no": {
-            "key": "PURGE",
+            "key": "REPLACE",
             "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
           }
         }
       },
+      "request_value_map": {},
       "response_key_map": {
-        "MAXDEPTH": "max_depth",
-        "DESCR": "description"
+        "ADOPTCTX": "adopt_context",
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "AUTHENMD": "authentication_method",
+        "AUTHORMD": "authorization_method",
+        "AUTHTYPE": "authentication_info_type",
+        "BASEDNG": "base_dn_group",
+        "BASEDNU": "base_dn_user",
+        "CHCKCLNT": "check_client",
+        "CHCKLOCL": "check_local",
+        "CLASSGRP": "class_group",
+        "CLASSUSR": "class_user",
+        "CONNAME": "connection_name",
+        "DESCR": "description",
+        "FAILDLAY": "failure_delay",
+        "FINDGRP": "find_group",
+        "GRPFIELD": "group_field",
+        "LDAPPWD": "ldap_password",
+        "LDAPUSER": "ldap_user_name",
+        "NESTGRP": "group_nesting",
+        "OCSPURL": "ocsp_responder_url",
+        "QSGDISP": "queue_sharing_group_disposition",
+        "SECCOMM": "secure_communications",
+        "SHORTUSR": "short_user",
+        "USRFIELD": "user_field"
+      },
+      "response_value_map": {}
+    },
+    "authrec": {
+      "request_key_map": {
+        "authority_add": "AUTHADD",
+        "authority_remove": "AUTHRMV",
+        "group_names": "GROUP",
+        "ignore_state": "IGNSTATE",
+        "object_type": "OBJTYPE",
+        "options": "MATCH",
+        "principal_names": "PRINCIPAL",
+        "profile_name": "PROFILE",
+        "service_component": "SERVCOMP"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "authserv": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {
+        "IFVER": "interface_version",
+        "UIDSUPP": "user_id_support"
+      },
+      "response_value_map": {}
+    },
+    "bsds": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "buffpool": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "cfstatus": {
+      "request_key_map": {
+        "shared_message_dataset": "SMDS"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ACCESS": "access",
+        "BKUPDATE": "backup_date",
+        "BKUPERBA": "backup_end_rba",
+        "BKUPSIZE": "backup_size",
+        "BKUPSRBA": "backup_start_rba",
+        "BKUPTIME": "backup_time",
+        "CFTYPE": "cf_struct_type",
+        "ENTSMAX": "entries_max",
+        "ENTSUSED": "entries_used",
+        "FAILDATE": "fail_date",
+        "FAILTIME": "fail_time",
+        "LOGS": "log_queue_manager_names",
+        "OFFLDUSE": "offload_use",
+        "QMNAME": "queue_manager_name",
+        "RCVDATE": "recovery_start_date",
+        "RCVTIME": "recovery_start_time",
+        "SIZEMAX": "size_max",
+        "SIZEUSED": "size_used",
+        "SMDS": "shared_message_dataset",
+        "STATUS": "cf_status_type",
+        "SYSNAME": "system_name"
+      },
+      "response_value_map": {}
+    },
+    "cfstruct": {
+      "request_key_map": {
+        "action": "ACTION",
+        "cf_connection_lost": "CFCONLOS",
+        "cf_level": "CFLEVEL",
+        "command_scope": "CMDSCOPE",
+        "data_sharing_block": "DSBLOCK",
+        "data_sharing_buffers": "DSBUFS",
+        "data_sharing_expand": "DSEXPAND",
+        "data_sharing_group": "DSGROUP",
+        "description": "DESCR",
+        "exclude_interval": "EXCLINT",
+        "like": "LIKE",
+        "offload": "OFFLOAD",
+        "offload_size1": "OFFLD1SZ",
+        "offload_size2": "OFFLD2SZ",
+        "offload_size3": "OFFLD3SZ",
+        "offload_threshold1": "OFFLD1TH",
+        "offload_threshold2": "OFFLD2TH",
+        "offload_threshold3": "OFFLD3TH",
+        "purge": "TYPE",
+        "recovery_auto": "RECAUTO",
+        "recovery": "RECOVER"
+      },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {
+        "purge": {
+          "no": "NORMAL",
+          "yes": "PURGE"
+        }
+      },
+      "response_key_map": {
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "CFCONLOS": "cf_connection_lost",
+        "CFLEVEL": "cf_level",
+        "DESCR": "description",
+        "DSBLOCK": "data_sharing_block",
+        "DSBUFS": "data_sharing_buffers",
+        "DSEXPAND": "data_sharing_expand",
+        "DSGROUP": "data_sharing_group",
+        "OFFLD1SZ": "offload_size1",
+        "OFFLD1TH": "offload_threshold1",
+        "OFFLD2SZ": "offload_size2",
+        "OFFLD2TH": "offload_threshold2",
+        "OFFLD3SZ": "offload_size3",
+        "OFFLD3TH": "offload_threshold3",
+        "OFFLOAD": "offload",
+        "RECAUTO": "recovery_auto",
+        "RECOVER": "recovery"
+      },
+      "response_value_map": {}
+    },
+    "channel": {
+      "request_key_map": {
+        "amqp_keep_alive": "AMQPKA",
+        "backlog": "BACKLOG",
+        "batch_data_limit": "BATCHLIM",
+        "batch_heartbeat": "BATCHHB",
+        "batch_interval": "BATCHINT",
+        "batch_size": "BATCHSZ",
+        "certificate_label": "CERTLABL",
+        "channel_disposition": "CHLDISP",
+        "channel_monitoring": "MONCHL",
+        "channel_statistics": "STATCHL",
+        "channel_status": "STATUS",
+        "channel_table": "CHLTABLE",
+        "channel_type": "CHLTYPE",
+        "client_channel_weight": "CLNTWGHT",
+        "client_id": "CLIENTID",
+        "cluster_name": "CLUSTER",
+        "cluster_namelist": "CLUSNL",
+        "cluster_workload_channel_weight": "CLWLWGHT",
+        "cluster_workload_priority": "CLWLPRTY",
+        "cluster_workload_rank": "CLWLRANK",
+        "command_scope": "CMDSCOPE",
+        "connection_affinity": "AFFINITY",
+        "connection_name": "CONNAME",
+        "data_conversion": "CONVERT",
+        "data_count": "DATALEN",
+        "default_reconnect": "DEFRECON",
+        "default_channel_disposition": "DEFCDISP",
+        "description": "DESCR",
+        "disconnect_interval": "DISCINT",
+        "header_compression": "COMPHDR",
+        "heartbeat_interval": "HBINT",
+        "ignore_state": "IGNSTATE",
+        "in_doubt": "ACTION",
+        "jaas_config": "JAASCFG",
+        "keep_alive_interval": "KAINT",
+        "like": "LIKE",
+        "local_address": "LOCLADDR",
+        "long_retry_count": "LONGRTY",
+        "long_retry_interval": "LONGTMR",
+        "max_instances": "MAXINST",
+        "max_instances_per_client": "MAXINSTC",
+        "max_message_length": "MAXMSGL",
+        "mca_name": "MCANAME",
+        "mca_type": "MCATYPE",
+        "mca_user": "MCAUSER",
+        "message_compression": "COMPMSG",
+        "message_exit": "MSGEXIT",
+        "message_retry_count": "MRRTY",
+        "message_retry_exit": "MREXIT",
+        "message_retry_interval": "MRTMR",
+        "message_retry_user_data": "MRDATA",
+        "message_sequence_number": "SEQNUM",
+        "message_user_data": "MSGDATA",
+        "mode": "MODE",
+        "mode_name": "MODENAME",
+        "network_priority": "NETPRTY",
+        "non_persistent_message_speed": "NPMSPEED",
+        "password": "PASSWORD",
+        "port": "PORT",
+        "property_control": "PROPCTL",
+        "protocol": "PROTOCOL",
+        "put_authority": "PUTAUT",
+        "queue_manager_name": "QMNAME",
+        "queue_sharing_group_disposition": "QSGDISP",
+        "receive_exit": "RCVEXIT",
+        "receive_user_data": "RCVDATA",
+        "security_exit": "SCYEXIT",
+        "security_user_data": "SCYDATA",
+        "send_exit": "SENDEXIT",
+        "send_user_data": "SENDDATA",
+        "sequence_number_wrap": "SEQWRAP",
+        "sharing_conversations": "SHARECNV",
+        "short_retry_count": "SHORTRTY",
+        "short_retry_interval": "SHORTTMR",
+        "security_policy_protection": "SPLPROT",
+        "ssl_cipher_spec": "SSLCIPH",
+        "ssl_client_authentication": "SSLCAUTH",
+        "ssl_key_repository": "SSLKEYR",
+        "ssl_pass_phrase": "SSLKEYP",
+        "ssl_peer_name": "SSLPEER",
+        "temporary_model_queue_name": "TMPMODEL",
+        "temporary_queue_prefix": "TMPQPRFX",
+        "topic_root": "TPROOT",
+        "transaction_program_name": "TPNAME",
+        "transmission_queue_name": "XMITQ",
+        "transport_type": "TRPTYPE",
+        "use_client_id": "USECLTID",
+        "use_dead_letter_queue": "USEDLQ",
+        "user_id": "USERID"
+      },
+      "request_key_value_map": {
+        "channel_instance_type": {
+          "current": {
+            "key": "CURRENT",
+            "value": "YES"
+          },
+          "saved": {
+            "key": "SAVED",
+            "value": "YES"
+          },
+          "short": {
+            "key": "SHORT",
+            "value": "YES"
+          }
+        },
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "AFFINITY": "connection_affinity",
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "AMQPKA": "amqp_keep_alive",
+        "AUTOSTART": "auto_start",
+        "BATCHHB": "batch_heartbeat",
+        "BATCHINT": "batch_interval",
+        "BATCHLIM": "batch_data_limit",
+        "BATCHSZ": "batch_size",
+        "CERTLABL": "certificate_label",
+        "CHLTYPE": "channel_type",
+        "CLNTWGHT": "client_channel_weight",
+        "CLUSNL": "cluster_namelist",
+        "CLUSTER": "cluster_name",
+        "CLWLPRTY": "cluster_workload_priority",
+        "CLWLRANK": "cluster_workload_rank",
+        "CLWLWGHT": "cluster_workload_channel_weight",
+        "COMPHDR": "header_compression",
+        "COMPMSG": "message_compression",
+        "CONNAME": "connection_name",
+        "CONVERT": "data_conversion",
+        "DEFCDISP": "default_channel_disposition",
+        "DESCR": "description",
+        "DISCINT": "disconnect_interval",
+        "HBINT": "heartbeat_interval",
+        "KAINT": "keep_alive_interval",
+        "LOCLADDR": "local_address",
+        "LONGRTY": "long_retry_count",
+        "LONGTMR": "long_retry_interval",
+        "MAXINST": "max_instances",
+        "MAXINSTC": "max_instances_per_client",
+        "MAXMSGL": "max_message_length",
+        "MCANAME": "mca_name",
+        "MCATYPE": "mca_type",
+        "MCAUSER": "mca_user",
+        "MODENAME": "mode_name",
+        "MONCHL": "channel_monitoring",
+        "MRDATA": "message_retry_user_data",
+        "MREXIT": "message_retry_exit",
+        "MRRTY": "message_retry_count",
+        "MRTMR": "message_retry_interval",
+        "MSGDATA": "message_user_data",
+        "MSGEXIT": "message_exit",
+        "NETPRTY": "network_priority",
+        "NPMSPEED": "non_persistent_message_speed",
+        "PASSWORD": "password",
+        "PORT": "port",
+        "PROPCTL": "property_control",
+        "PUTAUT": "put_authority",
+        "QMNAME": "queue_manager_name",
+        "RCVDATA": "receive_user_data",
+        "RCVEXIT": "receive_exit",
+        "RESETSEQ": "reset_sequence",
+        "SCYDATA": "security_user_data",
+        "SCYEXIT": "security_exit",
+        "SENDDATA": "send_user_data",
+        "SENDEXIT": "send_exit",
+        "SEQWRAP": "sequence_number_wrap",
+        "SHARECNV": "sharing_conversations",
+        "SHORTRTY": "short_retry_count",
+        "SHORTTMR": "short_retry_interval",
+        "SPLPROT": "security_policy_protection",
+        "SSLCAUTH": "ssl_client_authentication",
+        "SSLCIPH": "ssl_cipher_spec",
+        "SSLPEER": "ssl_peer_name",
+        "STATCHL": "channel_statistics",
+        "TPNAME": "transaction_program_name",
+        "TPROOT": "topic_root",
+        "TRPTYPE": "transport_type",
+        "USECLTID": "use_client_id",
+        "USEDLQ": "use_dead_letter_queue",
+        "USERID": "user_id",
+        "XMITQ": "transmission_queue_name"
+      },
+      "response_value_map": {}
+    },
+    "chinit": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "environment_info": "ENVPARM",
+        "initiation_queue_name": "INITQ",
+        "shared_channel_restart": "SHARED"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "chlauth": {
+      "request_key_map": {
+        "action": "ACTION",
+        "address_list": "ADDRLIST",
+        "address": "ADDRESS",
+        "check_client": "CHCKCLNT",
+        "client_user": "CLNTUSER",
+        "command_scope": "CMDSCOPE",
+        "custom": "CUSTOM",
+        "description": "DESCR",
+        "match": "MATCH",
+        "mca_user": "MCAUSER",
+        "queue_manager_name": "QMNAME",
+        "ssl_certificate_issuer": "SSLCERTI",
+        "ssl_peer_name": "SSLPEER",
+        "type": "TYPE",
+        "user_list": "USERLIST",
+        "user_source": "USERSRC",
+        "warn": "WARN"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ADDRESS": "address",
+        "ADDRLIST": "address_list",
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "CHCKCLNT": "check_client",
+        "CLNTUSER": "client_user",
+        "CUSTOM": "custom",
+        "DESCR": "description",
+        "MCAUSER": "mca_user",
+        "QMNAME": "queue_manager_name",
+        "SSLCERTI": "ssl_certificate_issuer",
+        "SSLPEER": "ssl_peer_name",
+        "TYPE": "type",
+        "USERLIST": "user_list"
+      },
+      "response_value_map": {}
+    },
+    "chstatus": {
+      "request_key_map": {
+        "channel_disposition": "CHLDISP",
+        "command_scope": "CMDSCOPE",
+        "connection_name": "CONNAME",
+        "non_persistent_message_speed": "NPMSPEED",
+        "transmission_queue_name": "XMITQ"
+      },
+      "request_key_value_map": {
+        "channel_instance_type": {
+          "current": {
+            "key": "CURRENT",
+            "value": "YES"
+          },
+          "saved": {
+            "key": "SAVED",
+            "value": "YES"
+          },
+          "short": {
+            "key": "SHORT",
+            "value": "YES"
+          }
+        },
+        "monitor": {
+          "no": {
+            "key": "MONITOR",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "MONITOR",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "AMQPKA": "amqp_keep_alive",
+        "BATCHES": "batches",
+        "BATCHSZ": "batch_size",
+        "BUFSRCVD": "buffers_received",
+        "BUFSSENT": "buffers_sent",
+        "BYTSRCVD": "bytes_received",
+        "BYTSSENT": "bytes_sent",
+        "CHLTYPE": "channel_type",
+        "CHSTADA": "channel_start_date",
+        "CHSTATI": "channel_start_time",
+        "COMPHDR": "header_compression",
+        "COMPMSG": "message_compression",
+        "COMPRATE": "compression_rate",
+        "COMPTIME": "compression_time",
+        "CURLUWID": "current_logical_unit_of_work_id",
+        "CURMSGS": "current_messages",
+        "CURSEQNO": "current_sequence_number",
+        "CURSHCNV": "current_sharing_conversations",
+        "EXITTIME": "exit_time",
+        "HBINT": "heartbeat_interval",
+        "INDOUBT": "in_doubt_input",
+        "JOBNAME": "mca_job_name",
+        "KAINT": "keep_alive_interval",
+        "LOCLADDR": "local_address",
+        "LONGRTS": "long_retries_left",
+        "LSTLUWID": "last_logical_unit_of_work_id",
+        "LSTMSGDA": "last_message_date",
+        "LSTMSGTI": "last_message_time",
+        "LSTSEQNO": "last_sequence_number",
+        "MAXMSGL": "max_message_length",
+        "MAXSHCNV": "max_sharing_conversations",
+        "MCASTAT": "mca_status",
+        "MCAUSER": "mca_user",
+        "MONCHL": "channel_monitoring",
+        "MSGS": "messages",
+        "NETTIME": "net_time",
+        "NPMSPEED": "non_persistent_message_speed",
+        "PORT": "port",
+        "QMNAME": "queue_manager_name",
+        "RAPPLTAG": "remote_application_tag",
+        "RPRODUCT": "remote_product",
+        "RQMNAME": "remote_queue_manager_name",
+        "RVERSION": "remote_version",
+        "SECPROT": "security_protocol",
+        "SHORTRTS": "short_retries_left",
+        "SSLCERTI": "ssl_certificate_issuer",
+        "SSLCERTU": "ssl_certificate_user_id",
+        "SSLCIPH": "ssl_cipher_spec",
+        "SSLKEYDA": "ssl_key_reset_date",
+        "SSLKEYTI": "ssl_key_reset_time",
+        "SSLPEER": "ssl_peer_name",
+        "SSLRKEYS": "ssl_key_resets",
+        "STATCHL": "channel_statistics",
+        "STATUS": "channel_status",
+        "STOPREQ": "stop_requested",
+        "SUBSTATE": "sub_state",
+        "TPROOT": "topic_root",
+        "XBATCHSZ": "batch_size_indicator",
+        "XQMSGSA": "messages_available",
+        "XQTIME": "transmission_queue_time"
+      },
+      "response_value_map": {}
+    },
+    "clusqmgr": {
+      "request_key_map": {
+        "channel_name": "CHANNEL",
+        "cluster_name": "CLUSTER",
+        "command_scope": "CMDSCOPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "CLUSDATE": "cluster_date",
+        "CLUSTIME": "cluster_time",
+        "DEFTYPE": "definition_type",
+        "QMID": "queue_manager_id",
+        "QMTYPE": "queue_manager_type",
+        "STATUS": "channel_status",
+        "SUSPEND": "suspend",
+        "VERSION": "version",
+        "XMITQ": "transmission_queue_name"
+      },
+      "response_value_map": {}
+    },
+    "cluster": {
+      "request_key_map": {
+        "action": "ACTION",
+        "command_scope": "CMDSCOPE",
+        "queue_manager_id": "QMID",
+        "queue_manager_name": "QMNAME",
+        "refresh_repository": "REPOS",
+        "remove_queues": "QUEUES"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "cmdserv": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "comminfo": {
+      "request_key_map": {
+        "bridge": "BRIDGE",
+        "coded_character_set_id": "CCSID",
+        "communication_event": "COMMEV",
+        "description": "DESCR",
+        "encoding": "ENCODING",
+        "group_address": "GRPADDR",
+        "ignore_state": "IGNSTATE",
+        "like": "LIKE",
+        "message_history": "MSGHIST",
+        "monitor_interval": "MONINT",
+        "multicast_heartbeat": "MCHBINT",
+        "multicast_property_control": "MCPROP",
+        "new_subscription_history": "NSUBHIST",
+        "port": "PORT",
+        "type": "TYPE"
+      },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "BRIDGE": "bridge",
+        "CCSID": "coded_character_set_id",
+        "COMMEV": "communication_event",
+        "DESCR": "description",
+        "ENCODING": "encoding",
+        "GRPADDR": "group_address",
+        "MCHBINT": "multicast_heartbeat",
+        "MCPROP": "multicast_property_control",
+        "MONINT": "monitor_interval",
+        "MSGHIST": "message_history",
+        "NSUBHIST": "new_subscription_history",
+        "PORT": "port",
+        "TYPE": "type"
+      },
+      "response_value_map": {}
+    },
+    "conn": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "connection_info_type": "TYPE",
+        "connection_prefix": "EXTCONN",
+        "unit_of_recovery_disposition": "URDISP"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "APPLDESC": "application_description",
+        "APPLTAG": "application_tag",
+        "APPLTYPE": "application_type",
+        "CHANNEL": "channel_name",
+        "CLIENTID": "client_id",
+        "CONNAME": "connection_name",
+        "CONNOPTS": "connection_options",
+        "CONNTAG": "connection_tag",
+        "DEST": "destination",
+        "DESTQMGR": "destination_queue_manager",
+        "EXTURID": "unit_of_work_id",
+        "HSTATE": "handle_state",
+        "OBJNAME": "object_name",
+        "OBJTYPE": "object_type",
+        "OPENOPTS": "open_options",
+        "PID": "process_id",
+        "PSBNAME": "program_spec_block_name",
+        "PSTID": "partition_spec_table_region_id",
+        "QMURID": "queue_manager_unit_of_work_id",
+        "QSGDISP": "queue_sharing_group_disposition",
+        "READA": "read_ahead",
+        "SUBID": "subscription_id",
+        "SUBNAME": "subscription_name",
+        "TASKNO": "task_number",
+        "TID": "thread_id",
+        "TOPICSTR": "topic_string",
+        "TRANSID": "transaction_id",
+        "TYPE": "connection_info_type",
+        "UOWLOG": "start_unit_of_work_log_extent",
+        "UOWLOGDA": "unit_of_work_log_start_date",
+        "UOWLOGTI": "unit_of_work_log_start_time",
+        "UOWSTATE": "unit_of_work_state",
+        "UOWSTDA": "unit_of_work_start_date",
+        "UOWSTTI": "unit_of_work_start_time",
+        "URTYPE": "unit_of_work_type",
+        "USERID": "user_id"
+      },
+      "response_value_map": {}
+    },
+    "entauth": {
+      "request_key_map": {
+        "group_name": "GROUP",
+        "object_name": "OBJNAME",
+        "principal_name": "PRINCIPAL",
+        "service_component": "SERVCOMP"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "group": {
+      "request_key_map": {
+        "obsolete_db2_messages": "OBSMSGS"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "indoubt": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "in_doubt": "ACTION",
+        "origin_id": "NID",
+        "queue_manager_name": "QMNAME"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "listener": {
+      "request_key_map": {
+        "adapter": "ADAPTER",
+        "backlog": "BACKLOG",
+        "command_scope": "CMDSCOPE",
+        "commands": "COMMANDS",
+        "description": "DESCR",
+        "ignore_state": "IGNSTATE",
+        "inbound_disposition": "INDISP",
+        "ip_address": "IPADDR",
+        "like": "LIKE",
+        "local_name": "LOCLNAME",
+        "lu_name": "LUNAME",
+        "netbios_names": "NTBNAMES",
+        "port": "PORT",
+        "sessions": "SESSIONS",
+        "socket": "SOCKET",
+        "start_mode": "CONTROL",
+        "transaction_program_name": "TPNAME",
+        "transport_type": "TRPTYPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ADAPTER": "adapter",
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "BACKLOG": "backlog",
+        "COMMANDS": "commands",
+        "CONTROL": "start_mode",
+        "DESCR": "description",
+        "IPADDR": "ip_address",
+        "LOCLNAME": "local_name",
+        "NTBNAMES": "netbios_names",
+        "PORT": "port",
+        "SESSIONS": "sessions",
+        "SOCKET": "socket",
+        "TPNAME": "transaction_program_name"
+      },
+      "response_value_map": {}
+    },
+    "log": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "deallocate_interval": "DEALLCT",
+        "log_compression": "COMPLOG",
+        "max_archive_log": "MAXARCH",
+        "max_concurrent_offloads": "MAXCNOFF",
+        "max_read_tape_units": "MAXRTU",
+        "output_buffer_count": "WRTHRSH",
+        "z_hyper_link": "ZHYLINK",
+        "z_hyper_write": "ZHYWRITE"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "COMMANDS": "commands"
+      },
+      "response_value_map": {}
+    },
+    "lsstatus": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {
+        "ADAPTER": "adapter",
+        "BACKLOG": "backlog",
+        "CONTROL": "start_mode",
+        "DESCR": "description",
+        "IPADDR": "ip_address",
+        "LOCLNAME": "local_name",
+        "NTBNAMES": "netbios_names",
+        "PID": "process_id",
+        "PORT": "port",
+        "SESSIONS": "sessions",
+        "SOCKET": "socket",
+        "STARTDA": "start_date",
+        "STARTTI": "start_time",
+        "STATUS": "status",
+        "TPNAME": "transaction_program_name",
+        "TRPTYPE": "transport_type"
+      },
+      "response_value_map": {}
+    },
+    "maxsmsgs": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "namelist": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "description": "DESCR",
+        "ignore_state": "IGNSTATE",
+        "like": "LIKE",
+        "namelist_type": "NLTYPE",
+        "names": "NAMES",
+        "queue_sharing_group_disposition": "QSGDISP"
+      },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "DESCR": "description",
+        "NAMCOUNT": "name_count",
+        "NAMES": "names"
+      },
+      "response_value_map": {}
+    },
+    "policy": {
+      "request_key_map": {
+        "action": "ACTION",
+        "encryption_algorithm": "ENCALG",
+        "enforce": "ENFORCE",
+        "ignore_state": "IGNSTATE",
+        "key_reuse": "KEYREUSE",
+        "recipient": "RECIP",
+        "sign_algorithm": "SIGNALG",
+        "signer": "SIGNER",
+        "tolerate": "TOLERATE"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "process": {
+      "request_key_map": {
+        "application_id": "APPLICID",
+        "application_type": "APPLTYPE",
+        "command_scope": "CMDSCOPE",
+        "description": "DESCR",
+        "environment_data": "ENVRDATA",
+        "ignore_state": "IGNSTATE",
+        "like": "LIKE",
+        "queue_sharing_group_disposition": "QSGDISP",
+        "user_data": "USERDATA"
+      },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "APPLICID": "application_id",
+        "APPLTYPE": "application_type",
+        "DESCR": "description",
+        "ENVRDATA": "environment_data",
+        "USERDATA": "user_data"
+      },
+      "response_value_map": {}
+    },
+    "psid": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "pubsub": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "type": "TYPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "QMNAME": "queue_manager_name",
+        "STATUS": "status",
+        "SUBCOUNT": "subscription_count",
+        "TPCOUNT": "topic_node_count"
+      },
+      "response_value_map": {}
+    },
+    "qmgr": {
+      "request_key_map": {
+        "accounting_connection_override": "ACCTCONO",
+        "accounting_interval": "ACCTINT",
+        "activity_connection_override": "ACTVCONO",
+        "activity_recording": "ACTIVREC",
+        "activity_trace": "ACTVTRC",
+        "adopt_new_mca_check": "ADOPTCHK",
+        "adopt_new_mca_type": "ADOPTMCA",
+        "authority_event": "AUTHOREV",
+        "authority_event_scope": "AUTHEVSC",
+        "bridge_event": "BRIDGEEV",
+        "certificate_label": "CERTLABL",
+        "certificate_validation_policy": "CERTVPOL",
+        "cf_connection_lost": "CFCONLOS",
+        "channel_authentication_records": "CHLAUTH",
+        "channel_auto_define": "CHAD",
+        "channel_auto_define_event": "CHADEV",
+        "channel_auto_define_exit": "CHADEXIT",
+        "channel_event": "CHLEV",
+        "channel_initiator_control": "SCHINIT",
+        "channel_monitoring": "MONCHL",
+        "channel_statistics": "STATCHL",
+        "chinit_adapters": "CHIADAPS",
+        "chinit_dispatchers": "CHIDISPS",
+        "chinit_service_parameter": "CHISERVP",
+        "chinit_trace_auto_start": "TRAXSTR",
+        "chinit_trace_table_size": "TRAXTBL",
+        "cluster_namelist": "CLUSNL",
+        "cluster_sender_monitoring_default": "MONACLS",
+        "cluster_sender_statistics": "STATACLS",
+        "cluster_work_load_data": "CLWLDATA",
+        "cluster_work_load_exit": "CLWLEXIT",
+        "cluster_work_load_length": "CLWLLEN",
+        "cluster_workload_mru_channels": "CLWLMRUC",
+        "cluster_workload_use_queue": "CLWLUSEQ",
+        "coded_character_set_id": "CCSID",
+        "command_event": "CMDEV",
+        "command_scope": "CMDSCOPE",
+        "command_server_control": "SCMDSERV",
+        "configuration_event": "CONFIGEV",
+        "connection_authentication": "CONNAUTH",
+        "custom": "CUSTOM",
+        "dead_letter_queue_name": "DEADQ",
+        "default_cluster_transmission_queue_type": "DEFCLXQ",
+        "default_transmission_queue_name": "DEFXMITQ",
+        "description": "DESCR",
+        "encryption_policy_suite_b": "SUITEB",
+        "expiry_interval": "EXPRYINT",
+        "facility": "FACILITY",
+        "force": "FORCE",
+        "group_unit_of_recovery": "GROUPUR",
+        "intragroup_queueing_put_authority": "IGQAUT",
+        "intragroup_queueing_user_id": "IGQUSER",
+        "image_interval": "IMGINTVL",
+        "image_log_length": "IMGLOGLN",
+        "image_recover_object": "IMGRCOVO",
+        "image_recover_queue": "IMGRCOVQ",
+        "image_schedule": "IMGSCHED",
+        "inhibit_event": "INHIBTEV",
+        "initial_key": "INITKEY",
+        "ip_address_version": "IPADDRV",
+        "listener_timer": "LSTRTMR",
+        "local_event": "LOCALEV",
+        "logger_event": "LOGGEREV",
+        "lu62_arm_suffix": "LU62ARM",
+        "lu62_channels": "LU62CHL",
+        "lu_group_name": "LUGROUP",
+        "lu_name": "LUNAME",
+        "max_active_channels": "ACTCHL",
+        "max_channels": "MAXCHL",
+        "max_handles": "MAXHANDS",
+        "max_message_length": "MAXMSGL",
+        "max_properties_length": "MAXPROPL",
+        "max_uncommitted_messages": "MAXUMSGS",
+        "message_mark_browse_interval": "MARKINT",
+        "mqi_accounting": "ACCTMQI",
+        "mqi_statistics": "STATMQI",
+        "native_ha_type": "NHATYPE",
+        "object_type": "OBJECT",
+        "otel_propagation_control": "OTELPCTL",
+        "otel_trace": "OTELTRAC",
+        "outbound_port_max": "OPORTMAX",
+        "outbound_port_min": "OPORTMIN",
+        "parent": "PARENT",
+        "performance_event": "PERFMEV",
+        "pub_sub_cluster": "PSCLUS",
+        "pub_sub_max_message_retry_count": "PSRTYCNT",
+        "pub_sub_mode": "PSMODE",
+        "pub_sub_non_persistent_input_message": "PSNPMSG",
+        "pub_sub_non_persistent_response": "PSNPRES",
+        "pub_sub_sync_point": "PSSYNCPT",
+        "queue_sharing_group_certificate_label": "CERTQSGL",
+        "queue_accounting": "ACCTQ",
+        "queue_monitoring": "MONQ",
+        "queue_statistics": "STATQ",
+        "receive_timeout": "RCVTIME",
+        "receive_timeout_min": "RCVTMIN",
+        "receive_timeout_type": "RCVTTYPE",
+        "refresh_interval": "INCLINT",
+        "remote_event": "REMOTEEV",
+        "repository_name": "REPOS",
+        "repository_namelist": "REPOSNL",
+        "reverse_dns": "REVDNS",
+        "security_case": "SCYCASE",
+        "shared_queue_queue_manager_name": "SQQMNAME",
+        "ssl_crypto_hardware": "SSLCRYP",
+        "ssl_event": "SSLEV",
+        "ssl_fips_required": "SSLFIPS",
+        "ssl_key_repository": "SSLKEYR",
+        "ssl_key_repository_password": "KEYRPWD",
+        "ssl_key_reset_count": "SSLRKEYC",
+        "ssl_tasks": "SSLTASKS",
+        "sslcrl_namelist": "SSLCRLNL",
+        "start_stop_event": "STRSTPEV",
+        "statistics_interval": "STATINT",
+        "status_type": "TYPE",
+        "tcp_channels": "TCPCHL",
+        "tcp_keep_alive": "TCPKEEP",
+        "tcp_name": "TCPNAME",
+        "tcp_stack_type": "TCPSTACK",
+        "trace_route_recording": "ROUTEREC",
+        "tree_life_time": "TREELIFE",
+        "trigger_interval": "TRIGINT"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ACCTCONO": "accounting_connection_override",
+        "ACCTINT": "accounting_interval",
+        "ACCTMQI": "mqi_accounting",
+        "ACCTQ": "queue_accounting",
+        "ACTCHL": "max_active_channels",
+        "ACTIVREC": "activity_recording",
+        "ACTVCONO": "activity_connection_override",
+        "ACTVTRC": "activity_trace",
+        "ADOPTCHK": "adopt_new_mca_check",
+        "ADOPTMCA": "adopt_new_mca_type",
+        "ADVCAP": "advanced_capability",
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "AMQPCAP": "amqp_capability",
+        "ARCHLOG": "archive_log",
+        "ARCHSZ": "archive_log_size",
+        "AUTHEVSC": "authority_event_scope",
+        "AUTHOREV": "authority_event",
+        "AUTOCLUS": "auto_cluster",
+        "BRIDGEEV": "bridge_event",
+        "CCSID": "coded_character_set_id",
+        "CERTLABL": "certificate_label",
+        "CERTQSGL": "queue_sharing_group_certificate_label",
+        "CERTVPOL": "certificate_validation_policy",
+        "CFCONLOS": "cf_connection_lost",
+        "CHAD": "channel_auto_define",
+        "CHADEV": "channel_auto_define_event",
+        "CHADEXIT": "channel_auto_define_exit",
+        "CHIADAPS": "chinit_adapters",
+        "CHIDISPS": "chinit_dispatchers",
+        "CHISERVP": "chinit_service_parameter",
+        "CHKPTCNT": "checkpoint_count",
+        "CHKPTOPS": "checkpoint_operations",
+        "CHKPTSZ": "checkpoint_size",
+        "CHLAUTH": "channel_authentication_records",
+        "CHLEV": "channel_event",
+        "CLWLDATA": "cluster_work_load_data",
+        "CLWLEXIT": "cluster_work_load_exit",
+        "CLWLLEN": "cluster_work_load_length",
+        "CLWLMRUC": "cluster_workload_mru_channels",
+        "CLWLUSEQ": "cluster_workload_use_queue",
+        "CMDEV": "command_event",
+        "CMDLEVEL": "command_level",
+        "CMDSERV": "command_server_status",
+        "COMMANDQ": "command_input_queue_name",
+        "CONFIGEV": "configuration_event",
+        "CONNAUTH": "connection_authentication",
+        "CPILEVEL": "cpi_level",
+        "CRDATE": "creation_date",
+        "CRTIME": "creation_time",
+        "CURRLOG": "current_log",
+        "CUSTOM": "custom",
+        "DATFSSZ": "data_filesystem_size",
+        "DATFSUSE": "data_filesystem_use",
+        "DATPATH": "data_path",
+        "DEADQ": "dead_letter_queue_name",
+        "DEFCLXQ": "default_cluster_transmission_queue_type",
+        "DEFXMITQ": "default_transmission_queue_name",
+        "DESCR": "description",
+        "DISKLSN": "disk_log_sequence_number",
+        "DISTL": "distribution_lists",
+        "EXPRYINT": "expiry_interval",
+        "GROUPUR": "group_unit_of_recovery",
+        "GRPLSN": "group_log_sequence_number",
+        "GRPNAME": "group_name",
+        "GRPROLE": "group_role",
+        "HOSTNAME": "host_name",
+        "IGQAUT": "intragroup_queueing_put_authority",
+        "IGQUSER": "intragroup_queueing_user_id",
+        "IMGINTVL": "image_interval",
+        "IMGLOGLN": "image_log_length",
+        "IMGRCOVO": "image_recover_object",
+        "IMGRCOVQ": "image_recover_queue",
+        "IMGSCHED": "image_schedule",
+        "INHIBTEV": "inhibit_event",
+        "INITKEY": "initial_key",
+        "INSTANCE": "instance",
+        "INSTDESC": "installation_description",
+        "INSTNAME": "installation_name",
+        "INSTPATH": "installation_path",
+        "IPADDRV": "ip_address_version",
+        "KEYRPWD": "ssl_key_repository_password",
+        "LDAPCONN": "ldap_connection_status",
+        "LOCALEV": "local_event",
+        "LOGEXTSZ": "log_ext_size",
+        "LOGFSSZ": "log_filesystem_size",
+        "LOGFSUSE": "log_filesystem_use",
+        "LOGGEREV": "logger_event",
+        "LOGINUSE": "log_in_use",
+        "LOGPATH": "log_path",
+        "LOGPRIM": "log_primary",
+        "LOGSEC": "log_secondary",
+        "LOGSTRDA": "log_start_date",
+        "LOGSTRL": "log_start_log_sequence_number",
+        "LOGSTRTI": "log_start_time",
+        "LOGTYPE": "log_type",
+        "LOGUTIL": "log_utilization",
+        "LSTRTMR": "listener_timer",
+        "LU62ARM": "lu62_arm_suffix",
+        "LU62CHL": "lu62_channels",
+        "LUGROUP": "lu_group_name",
+        "LUNAME": "lu_name",
+        "MARKINT": "message_mark_browse_interval",
+        "MAXCHL": "max_channels",
+        "MAXHANDS": "max_handles",
+        "MAXMSGL": "max_message_length",
+        "MAXPROPL": "max_properties_length",
+        "MAXPRTY": "max_priority",
+        "MAXUMSGS": "max_uncommitted_messages",
+        "MEDIALOG": "media_recovery_log_extent",
+        "MEDIASZ": "media_recovery_log_size",
+        "MONACLS": "cluster_sender_monitoring_default",
+        "MONCHL": "channel_monitoring",
+        "MONQ": "queue_monitoring",
+        "OPORTMAX": "outbound_port_max",
+        "OPORTMIN": "outbound_port_min",
+        "OTELPCTL": "otel_propagation_control",
+        "OTELTRAC": "otel_trace",
+        "PARENT": "parent",
+        "PERFMEV": "performance_event",
+        "PLATFORM": "platform",
+        "PSCLUS": "pub_sub_cluster",
+        "PSMODE": "pub_sub_mode",
+        "PSNPMSG": "pub_sub_non_persistent_input_message",
+        "PSNPRES": "pub_sub_non_persistent_response",
+        "PSRTYCNT": "pub_sub_max_message_retry_count",
+        "PSSYNCPT": "pub_sub_sync_point",
+        "QMFSENC": "queue_manager_encryption",
+        "QMFSSZ": "queue_manager_filesystem_size",
+        "QMFSUSE": "queue_manager_filesystem_use",
+        "QMID": "queue_manager_id",
+        "QMNAME": "queue_manager_name",
+        "QSGNAME": "queue_sharing_group_name",
+        "QUORUM": "quorum",
+        "RCVTIME": "receive_timeout",
+        "RCVTMIN": "receive_timeout_min",
+        "RCVTTYPE": "receive_timeout_type",
+        "REMOTEEV": "remote_event",
+        "REPOS": "repository_name",
+        "REPOSNL": "repository_namelist",
+        "REUSESZ": "reusable_log_size",
+        "REVDNS": "reverse_dns",
+        "ROUTEREC": "trace_route_recording",
+        "SCHINIT": "channel_initiator_control",
+        "SCMDSERV": "command_server_control",
+        "SCYCASE": "security_case",
+        "SPLCAP": "security_policy_capability",
+        "SQQMNAME": "shared_queue_queue_manager_name",
+        "SSLCRLNL": "sslcrl_namelist",
+        "SSLCRYP": "ssl_crypto_hardware",
+        "SSLEV": "ssl_event",
+        "SSLFIPS": "ssl_fips_required",
+        "SSLKEYR": "ssl_key_repository",
+        "SSLRKEYC": "ssl_key_reset_count",
+        "SSLTASKS": "ssl_tasks",
+        "STANDBY": "permit_standby",
+        "STARTDA": "start_date",
+        "STARTTI": "start_time",
+        "STATACLS": "cluster_sender_statistics",
+        "STATCHL": "channel_statistics",
+        "STATINT": "statistics_interval",
+        "STATMQI": "mqi_statistics",
+        "STATQ": "queue_statistics",
+        "STATUS": "ha_status",
+        "STRSTPEV": "start_stop_event",
+        "SUITEB": "encryption_policy_suite_b",
+        "SYNCPT": "sync_point",
+        "TCPCHL": "tcp_channels",
+        "TCPKEEP": "tcp_keep_alive",
+        "TCPNAME": "tcp_name",
+        "TCPSTACK": "tcp_stack_type",
+        "TRAXSTR": "chinit_trace_auto_start",
+        "TRAXTBL": "chinit_trace_table_size",
+        "TREELIFE": "tree_life_time",
+        "TRIGINT": "trigger_interval",
+        "UNICLUS": "uniform_cluster_name",
+        "VERSION": "version",
+        "XRCAP": "telemetry_capability"
+      },
+      "response_value_map": {}
+    },
+    "qmstatus": {
+      "request_key_map": {
+        "native_ha_type": "NHATYPE",
+        "status_type": "TYPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ARCHLOG": "archive_log",
+        "ARCHSZ": "archive_log_size",
+        "AUTOCLUS": "auto_cluster",
+        "CHINIT": "channel_initiator_status",
+        "CHKPTCNT": "checkpoint_count",
+        "CHKPTOPS": "checkpoint_operations",
+        "CHKPTSZ": "checkpoint_size",
+        "CMDSERV": "command_server_status",
+        "CONNS": "connections",
+        "CURRLOG": "current_log",
+        "DATFSSZ": "data_filesystem_size",
+        "DATFSUSE": "data_filesystem_use",
+        "DATPATH": "data_path",
+        "DISKLSN": "disk_log_sequence_number",
+        "GRPLSN": "group_log_sequence_number",
+        "GRPNAME": "group_name",
+        "GRPROLE": "group_role",
+        "HOSTNAME": "host_name",
+        "INSTANCE": "instance",
+        "INSTDESC": "installation_description",
+        "INSTNAME": "installation_name",
+        "INSTPATH": "installation_path",
+        "LDAPCONN": "ldap_connection_status",
+        "LOGEXTSZ": "log_ext_size",
+        "LOGFSSZ": "log_filesystem_size",
+        "LOGFSUSE": "log_filesystem_use",
+        "LOGINUSE": "log_in_use",
+        "LOGPATH": "log_path",
+        "LOGPRIM": "log_primary",
+        "LOGSEC": "log_secondary",
+        "LOGSTRDA": "log_start_date",
+        "LOGSTRL": "log_start_log_sequence_number",
+        "LOGSTRTI": "log_start_time",
+        "LOGTYPE": "log_type",
+        "LOGUTIL": "log_utilization",
+        "MEDIALOG": "media_recovery_log_extent",
+        "MEDIASZ": "media_recovery_log_size",
+        "QMFSENC": "queue_manager_encryption",
+        "QMFSSZ": "queue_manager_filesystem_size",
+        "QMFSUSE": "queue_manager_filesystem_use",
+        "QMNAME": "queue_manager_name",
+        "QUORUM": "quorum",
+        "RECLOG": "recovery_log",
+        "RECSZ": "recovery_log_size",
+        "REUSESZ": "reusable_log_size",
+        "STANDBY": "permit_standby",
+        "STARTDA": "start_date",
+        "STARTTI": "start_time",
+        "STATUS": "ha_status",
+        "UNICLUS": "uniform_cluster_name"
+      },
+      "response_value_map": {}
+    },
+    "queue": {
+      "request_key_map": {
+        "authorization_record": "AUTHREC",
+        "backout_requeue_name": "BOQNAME",
+        "backout_threshold": "BOTHRESH",
+        "cf_struct_name": "CFSTRUCT",
+        "cluster_channel_name": "CLCHNAME",
+        "cluster_name": "CLUSTER",
+        "cluster_namelist": "CLUSNL",
+        "cluster_workload_priority": "CLWLPRTY",
+        "cluster_workload_rank": "CLWLRANK",
+        "cluster_workload_use_queue": "CLWLUSEQ",
+        "command_scope": "CMDSCOPE",
+        "custom": "CUSTOM",
+        "default_bind": "DEFBIND",
+        "default_input_open_option": "DEFSOPT",
+        "default_persistence": "DEFPSIST",
+        "default_priority": "DEFPRTY",
+        "default_read_ahead": "DEFREADA",
+        "default_put_response": "DEFPRESP",
+        "definition_type": "DEFTYPE",
+        "description": "DESCR",
+        "distribution_lists": "DISTL",
+        "force": "FORCE",
+        "harden_get_backout": "HARDENBO",
+        "ignore_state": "IGNSTATE",
+        "image_recover_queue": "IMGRCOVQ",
+        "inhibit_get": "GET",
+        "inhibit_put": "PUT",
+        "initiation_queue_name": "INITQ",
+        "like": "LIKE",
+        "max_message_length": "MAXMSGL",
+        "max_queue_depth": "MAXDEPTH",
+        "max_queue_file_size": "MAXFSIZE",
+        "message_delivery_sequence": "MSGDLVSQ",
+        "non_persistent_message_class": "NPMCLASS",
+        "page_set_id": "PSID",
+        "process_name": "PROCESS",
+        "property_control": "PROPCTL",
+        "queue_depth_high_event": "QDPHIEV",
+        "queue_depth_high_limit": "QDEPTHHI",
+        "queue_depth_low_event": "QDPLOEV",
+        "queue_depth_low_limit": "QDEPTHLO",
+        "queue_depth_max_event": "QDPMAXEV",
+        "queue_service_interval": "QSVCINT",
+        "queue_sharing_group_disposition": "QSGDISP",
+        "queue_accounting": "ACCTQ",
+        "queue_monitoring": "MONQ",
+        "queue_statistics": "STATQ",
+        "remote_queue_manager_name": "RQMNAME",
+        "remote_queue_name": "RNAME",
+        "retention_interval": "RETINTVL",
+        "scope": "SCOPE",
+        "shareability": "SHARE",
+        "storage_class": "STGCLASS",
+        "stream_queue": "STREAMQ",
+        "stream_queue_service": "STRMQOS",
+        "target_type": "TARGTYPE",
+        "to_queue_name": "TOQLOCAL",
+        "transmission_queue_name": "XMITQ",
+        "trigger_control": "TRIGGER",
+        "trigger_data": "TRIGDATA",
+        "trigger_depth": "TRIGDPTH",
+        "trigger_message_priority": "TRIGMPRI",
+        "trigger_type": "TRIGTYPE",
+        "usage": "USAGE"
+      },
+      "request_key_value_map": {
+        "nopurge": {
+          "yes": {
+            "key": "PURGE",
+            "value": "NO"
+          }
+        },
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "purge": {
+          "no": {
+            "key": "PURGE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "PURGE",
+            "value": "YES"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {
+        "default_persistence": {
+          "def": "DEF",
+          "not_fixed": "NOTFIXED"
+        }
+      },
+      "response_key_map": {
+        "ACCTQ": "queue_accounting",
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "APPLDESC": "application_description",
+        "APPLTAG": "application_tag",
+        "APPLTYPE": "application_type",
+        "ASID": "address_space_id",
+        "ASTATE": "asynchronous_state",
+        "BOQNAME": "backout_requeue_name",
+        "BOTHRESH": "backout_threshold",
+        "BROWSE": "open_browse",
+        "CAPEXPRY": "cap_expiry",
+        "CFSTRUCT": "cf_struct_name",
+        "CHANNEL": "channel_name",
+        "CLCHNAME": "cluster_channel_name",
+        "CLUSDATE": "cluster_date",
+        "CLUSNL": "cluster_namelist",
+        "CLUSQMGR": "cluster_queue_manager",
+        "CLUSQT": "cluster_queue_type",
+        "CLUSTER": "cluster_name",
+        "CLUSTIME": "cluster_time",
+        "CLWLPRTY": "cluster_workload_priority",
+        "CLWLRANK": "cluster_workload_rank",
+        "CLWLUSEQ": "cluster_workload_use_queue",
+        "CONNAME": "connection_name",
+        "CRDATE": "creation_date",
+        "CRTIME": "creation_time",
+        "CURDEPTH": "current_queue_depth",
+        "CURFSIZE": "current_queue_file_size",
+        "CURMAXFS": "current_max_queue_file_size",
+        "CUSTOM": "custom",
+        "DEFBIND": "default_bind",
+        "DEFPRESP": "default_put_response",
+        "DEFPRTY": "default_priority",
+        "DEFPSIST": "default_persistence",
+        "DEFREADA": "default_read_ahead",
+        "DEFSOPT": "default_input_open_option",
+        "DEFTYPE": "definition_type",
+        "DESCR": "description",
+        "DISTL": "distribution_lists",
+        "GET": "inhibit_get",
+        "HARDENBO": "harden_get_backout",
+        "HSTATE": "handle_state",
+        "IMGRCOVQ": "image_recover_queue",
+        "INDXTYPE": "index_type",
+        "INITQ": "initiation_queue_name",
+        "INQUIRE": "open_inquire",
+        "IPPROCS": "open_input_count",
+        "LGETDATE": "last_get_date",
+        "LGETTIME": "last_get_time",
+        "LPUTDATE": "last_put_date",
+        "LPUTTIME": "last_put_time",
+        "MAXDEPTH": "max_queue_depth",
+        "MAXFSIZE": "max_queue_file_size",
+        "MAXMSGL": "max_message_length",
+        "MEDIALOG": "media_recovery_log_extent",
+        "MONQ": "queue_monitoring",
+        "MSGAGE": "oldest_message_age",
+        "MSGDLVSQ": "message_delivery_sequence",
+        "NPMCLASS": "non_persistent_message_class",
+        "OPPROCS": "open_output_count",
+        "OTELPCTL": "otel_propagation_control",
+        "OTELTRAC": "otel_trace",
+        "OUTPUT": "open_output",
+        "PID": "process_id",
+        "PROCESS": "process_name",
+        "PROPCTL": "property_control",
+        "PSBNAME": "program_spec_block_name",
+        "PSID": "page_set_id",
+        "PSTID": "partition_spec_table_region_id",
+        "PUT": "inhibit_put",
+        "QDEPTHHI": "queue_depth_high_limit",
+        "QDEPTHLO": "queue_depth_low_limit",
+        "QDPHIEV": "queue_depth_high_event",
+        "QDPLOEV": "queue_depth_low_event",
+        "QDPMAXEV": "queue_depth_max_event",
+        "QMID": "queue_manager_id",
+        "QMURID": "queue_manager_unit_of_work_id",
+        "QSGDISP": "queue_sharing_group_disposition",
+        "QSVCINT": "queue_service_interval",
+        "QTIME": "on_queue_time",
+        "QTYPE": "queue_type",
+        "RETINTVL": "retention_interval",
+        "RNAME": "remote_queue_name",
+        "RQMNAME": "remote_queue_manager_name",
+        "SCOPE": "scope",
+        "SET": "open_set",
+        "SHARE": "shareability",
+        "STATQ": "queue_statistics",
+        "STGCLASS": "storage_class",
+        "STREAMQ": "stream_queue",
+        "STRMQOS": "stream_queue_service",
+        "TARGTYPE": "target_type",
+        "TASKNO": "task_number",
+        "TID": "thread_id",
+        "TPIPE": "tpipe_names",
+        "TRANSID": "transaction_id",
+        "TRIGDATA": "trigger_data",
+        "TRIGDPTH": "trigger_depth",
+        "TRIGGER": "trigger_control",
+        "TRIGMPRI": "trigger_message_priority",
+        "TRIGTYPE": "trigger_type",
+        "UNCOM": "uncommitted_messages",
+        "URID": "unit_of_work_id",
+        "URTYPE": "unit_of_work_type",
+        "USAGE": "usage",
+        "USERID": "user_id",
+        "XMITQ": "transmission_queue_name"
       },
       "response_value_map": {
-        "GET": {
-          "ENABLED": "enabled",
-          "DISABLED": "disabled"
+        "DEFPSIST": {
+          "DEF": "def",
+          "NOTFIXED": "not_fixed"
         }
       }
+    },
+    "qstatus": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "APPLDESC": "application_description",
+        "APPLTAG": "application_tag",
+        "APPLTYPE": "application_type",
+        "ASID": "address_space_id",
+        "ASTATE": "asynchronous_state",
+        "BROWSE": "open_browse",
+        "CHANNEL": "channel_name",
+        "CONNAME": "connection_name",
+        "CURDEPTH": "current_queue_depth",
+        "CURFSIZE": "current_queue_file_size",
+        "CURMAXFS": "current_max_queue_file_size",
+        "HSTATE": "handle_state",
+        "INPUT": "open_input",
+        "INQUIRE": "open_inquire",
+        "IPPROCS": "open_input_count",
+        "LGETDATE": "last_get_date",
+        "LGETTIME": "last_get_time",
+        "LPUTDATE": "last_put_date",
+        "LPUTTIME": "last_put_time",
+        "MEDIALOG": "media_recovery_log_extent",
+        "MONQ": "queue_monitoring",
+        "MSGAGE": "oldest_message_age",
+        "OPPROCS": "open_output_count",
+        "OUTPUT": "open_output",
+        "PID": "process_id",
+        "PSBNAME": "program_spec_block_name",
+        "PSTID": "partition_spec_table_region_id",
+        "QMURID": "queue_manager_unit_of_work_id",
+        "QSGDISP": "queue_sharing_group_disposition",
+        "QTIME": "on_queue_time",
+        "SET": "open_set",
+        "TASKNO": "task_number",
+        "TID": "thread_id",
+        "TRANSID": "transaction_id",
+        "TYPE": "status_type",
+        "UNCOM": "uncommitted_messages",
+        "URID": "unit_of_work_id",
+        "URTYPE": "unit_of_work_type",
+        "USERID": "user_id"
+      },
+      "response_value_map": {}
+    },
+    "sbstatus": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "durable": "DURABLE",
+        "subscription_type": "SUBTYPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ACTCONN": "active_connection",
+        "DURABLE": "durable",
+        "LMSGDATE": "last_message_date",
+        "LMSGTIME": "last_message_time",
+        "MCASTREL": "multicast_reliability_indicator",
+        "NUMMSGS": "number_of_messages",
+        "RESMDATE": "resume_date",
+        "RESMTIME": "resume_time",
+        "SUBID": "subscription_id",
+        "SUBTYPE": "subscription_type",
+        "SUBUSER": "subscription_user_id",
+        "TOPICSTR": "topic_string"
+      },
+      "response_value_map": {}
+    },
+    "security": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "security_interval": "INTERVAL",
+        "security_timeout": "TIMEOUT",
+        "security_type": "TYPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "service": {
+      "request_key_map": {
+        "description": "DESCR",
+        "ignore_state": "IGNSTATE",
+        "like": "LIKE",
+        "service_type": "SERVTYPE",
+        "start_arguments": "STARTARG",
+        "start_command": "STARTCMD",
+        "start_mode": "CONTROL",
+        "stderr_destination": "STDERR",
+        "stdout_destination": "STDOUT",
+        "stop_arguments": "STOPARG",
+        "stop_command": "STOPCMD"
+      },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "CONTROL": "start_mode",
+        "DESCR": "description",
+        "SERVTYPE": "service_type",
+        "STARTARG": "start_arguments",
+        "STARTCMD": "start_command",
+        "STDERR": "stderr_destination",
+        "STDOUT": "stdout_destination",
+        "STOPARG": "stop_arguments",
+        "STOPCMD": "stop_command"
+      },
+      "response_value_map": {}
+    },
+    "smds": {
+      "request_key_map": {
+        "access": "ACCESS",
+        "cf_struct_name": "CFSTRUCT",
+        "data_sharing_buffers": "DSBUFS",
+        "data_sharing_expand": "DSEXPAND",
+        "status": "STATUS"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "CFSTRUCT": "cf_struct_name",
+        "DSBUFS": "data_sharing_buffers",
+        "DSEXPAND": "data_sharing_expand",
+        "SMDS": "shared_message_dataset"
+      },
+      "response_value_map": {}
+    },
+    "smdsconn": {
+      "request_key_map": {
+        "cf_struct_name": "CFSTRUCT",
+        "command_scope": "CMDSCOPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "stgclass": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "description": "DESCR",
+        "like": "LIKE",
+        "page_set_id": "PSID",
+        "pass_ticket_application": "PASSTKTA",
+        "queue_sharing_group_disposition": "QSGDISP",
+        "xcf_group_name": "XCFGNAME",
+        "xcf_member_name": "XCFMNAME"
+      },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "DESCR": "description",
+        "PASSTKTA": "pass_ticket_application",
+        "XCFGNAME": "xcf_group_name",
+        "XCFMNAME": "xcf_member_name"
+      },
+      "response_value_map": {}
+    },
+    "sub": {
+      "request_key_map": {
+        "alteration_date": "ALTDATE",
+        "alteration_time": "ALTTIME",
+        "command_scope": "CMDSCOPE",
+        "creation_date": "CRDATE",
+        "creation_time": "CRTIME",
+        "destination": "DEST",
+        "destination_class": "DESTCLAS",
+        "destination_correlation_id": "DESTCORL",
+        "destination_queue_manager": "DESTQMGR",
+        "display_type": "DISTYPE",
+        "durable": "DURABLE",
+        "expiry": "EXPIRY",
+        "ignore_state": "IGNSTATE",
+        "publish_priority": "PUBPRTY",
+        "publish_subscribe_properties": "PSPROP",
+        "published_accounting_token": "PUBACCT",
+        "published_application_id": "PUBAPPID",
+        "request_only": "REQONLY",
+        "selector": "SELECTOR",
+        "selector_type": "SELTYPE",
+        "subscription_id": "SUBID",
+        "subscription_level": "SUBLEVEL",
+        "subscription_type": "SUBTYPE",
+        "subscription_user_id": "SUBUSER",
+        "topic_object": "TOPICOBJ",
+        "topic_string": "TOPICSTR",
+        "user_data": "USERDATA",
+        "variable_user": "VARUSER",
+        "wildcard_schema": "WSCHEMA"
+      },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "CMDSCOPE": "command_scope",
+        "CRDATE": "creation_date",
+        "CRTIME": "creation_time",
+        "DEST": "destination",
+        "DESTCLAS": "destination_class",
+        "DESTCORL": "destination_correlation_id",
+        "DESTQMGR": "destination_queue_manager",
+        "DISTYPE": "display_type",
+        "DURABLE": "durable",
+        "EXPIRY": "expiry",
+        "PSPROP": "publish_subscribe_properties",
+        "PUBACCT": "published_accounting_token",
+        "PUBAPPID": "published_application_id",
+        "PUBPRTY": "publish_priority",
+        "REQONLY": "request_only",
+        "SELECTOR": "selector",
+        "SELTYPE": "selector_type",
+        "SUB": "subscription_name",
+        "SUBID": "subscription_id",
+        "SUBLEVEL": "subscription_level",
+        "SUBTYPE": "subscription_type",
+        "SUBUSER": "subscription_user_id",
+        "TOPICOBJ": "topic_object",
+        "TOPICSTR": "topic_string",
+        "USERDATA": "user_data",
+        "VARUSER": "variable_user",
+        "WSCHEMA": "wildcard_schema"
+      },
+      "response_value_map": {}
+    },
+    "svstatus": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {
+        "CONTROL": "start_mode",
+        "DESCR": "description",
+        "PID": "process_id",
+        "SERVTYPE": "service_type",
+        "STARTARG": "start_arguments",
+        "STARTCMD": "start_command",
+        "STARTDA": "start_date",
+        "STARTTI": "start_time",
+        "STATUS": "status",
+        "STDERR": "stderr_destination",
+        "STDOUT": "stdout_destination",
+        "STOPARG": "stop_arguments",
+        "STOPCMD": "stop_command"
+      },
+      "response_value_map": {}
+    },
+    "tcluster": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "thread": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "topic": {
+      "request_key_map": {
+        "authorization_record": "AUTHREC",
+        "cap_expiry": "CAPEXPRY",
+        "cluster_name": "CLUSTER",
+        "cluster_publish_route": "CLROUTE",
+        "communication_info": "COMMINFO",
+        "command_scope": "CMDSCOPE",
+        "custom": "CUSTOM",
+        "default_persistence": "DEFPSIST",
+        "default_priority": "DEFPRTY",
+        "default_put_response": "DEFPRESP",
+        "description": "DESCR",
+        "durable_model_queue_name": "MDURMDL",
+        "durable_subscriptions": "DURSUB",
+        "ignore_state": "IGNSTATE",
+        "like": "LIKE",
+        "multicast": "MCAST",
+        "non_durable_model_queue_name": "MNDURMDL",
+        "non_persistent_message_delivery": "NPMSGDLV",
+        "persistent_message_delivery": "PMSGDLV",
+        "proxy_subscriptions": "PROXYSUB",
+        "publication_scope": "PUBSCOPE",
+        "queue_sharing_group_disposition": "QSGDISP",
+        "subscription_scope": "SUBSCOPE",
+        "topic_string": "TOPICSTR",
+        "topic_type": "TYPE",
+        "use_dead_letter_queue": "USEDLQ",
+        "wildcard_operation": "WILDCARD"
+      },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "CAPEXPRY": "cap_expiry",
+        "CLROUTE": "cluster_publish_route",
+        "CLSTATE": "cluster_object_state",
+        "CLUSTER": "cluster_name",
+        "COMMINFO": "communication_info",
+        "CUSTOM": "custom",
+        "DEFPRESP": "default_put_response",
+        "DEFPRTY": "default_priority",
+        "DEFPSIST": "default_persistence",
+        "DESCR": "description",
+        "DURSUB": "durable_subscriptions",
+        "MCAST": "multicast",
+        "MDURMDL": "durable_model_queue_name",
+        "MNDURMDL": "non_durable_model_queue_name",
+        "NPMSGDLV": "non_persistent_message_delivery",
+        "PMSGDLV": "persistent_message_delivery",
+        "PROXYSUB": "proxy_subscriptions",
+        "PUBSCOPE": "publication_scope",
+        "SUBSCOPE": "subscription_scope",
+        "TOPICSTR": "topic_string",
+        "TYPE": "topic_type",
+        "USEDLQ": "use_dead_letter_queue",
+        "WILDCARD": "wildcard_operation"
+      },
+      "response_value_map": {}
+    },
+    "topicstr": {
+      "request_key_map": {
+        "clear_type": "CLRTYPE",
+        "command_scope": "CMDSCOPE",
+        "scope": "SCOPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "tpipe": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "tpstatus": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "status_type": "TYPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ACTCONN": "active_connection",
+        "ADMIN": "admin_topic_name",
+        "CAPEXPRY": "cap_expiry",
+        "CLROUTE": "cluster_publish_route",
+        "CLUSTER": "cluster_name",
+        "COMMINFO": "communication_info",
+        "DEFPRESP": "default_put_response",
+        "DEFPRTY": "default_priority",
+        "DEFPSIST": "default_persistence",
+        "DURABLE": "durable",
+        "DURSUB": "durable_subscriptions",
+        "LMSGDATE": "last_message_date",
+        "LMSGTIME": "last_message_time",
+        "LPUBDATE": "last_publication_date",
+        "LPUBTIME": "last_publication_time",
+        "MCAST": "multicast",
+        "MCASTREL": "multicast_reliability_indicator",
+        "MDURMDL": "durable_model_queue_name",
+        "MNDURMDL": "non_durable_model_queue_name",
+        "NPMSGDLV": "non_persistent_message_delivery",
+        "NUMMSGS": "number_of_messages",
+        "NUMPUBS": "number_of_publishes",
+        "PMSGDLV": "persistent_message_delivery",
+        "PUBCOUNT": "publish_count",
+        "PUBSCOPE": "publication_scope",
+        "RESMDATE": "resume_date",
+        "RESMTIME": "resume_time",
+        "RETAINED": "retained_publication",
+        "SUBCOUNT": "subscription_count",
+        "SUBID": "subscription_id",
+        "SUBTYPE": "subscription_type",
+        "SUBUSER": "subscription_user_id",
+        "USEDLQ": "use_dead_letter_queue"
+      },
+      "response_value_map": {}
+    },
+    "trace": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "usage": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "page_set_id": "PSID",
+        "usage_type": "TYPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
     }
-  }
+  },
+  "version": 1
 }

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionTest.java
@@ -758,8 +758,8 @@ class MqRestSessionTest {
           session.mqscCommand("DISPLAY", "QUEUE", "Q1", null, null, null);
 
       assertThat(result).hasSize(1);
-      // Should have mapped MAXDEPTH → max_depth
-      assertThat(result.get(0)).containsKey("max_depth");
+      // Should have mapped MAXDEPTH → max_queue_depth
+      assertThat(result.get(0)).containsKey("max_queue_depth");
     }
 
     @Test
@@ -784,7 +784,7 @@ class MqRestSessionTest {
           .thenReturn(successResponse(emptyCommandResponse()));
 
       MqRestSession session = basicBuilder().mapAttributes(true).mappingStrict(false).build();
-      session.mqscCommand("ALTER", "QUEUE", "Q1", Map.of("max_depth", 5000), null, null);
+      session.mqscCommand("ALTER", "QUEUE", "Q1", Map.of("max_queue_depth", 5000), null, null);
 
       @SuppressWarnings("unchecked")
       ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
@@ -864,7 +864,7 @@ class MqRestSessionTest {
           .thenReturn(successResponse(emptyCommandResponse()));
 
       MqRestSession session = basicBuilder().mappingStrict(false).build();
-      session.mqscCommand("DISPLAY", "QUEUE", "Q1", null, List.of("max_depth"), null);
+      session.mqscCommand("DISPLAY", "QUEUE", "Q1", null, List.of("max_queue_depth"), null);
 
       @SuppressWarnings("unchecked")
       ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
@@ -972,7 +972,7 @@ class MqRestSessionTest {
           .thenReturn(successResponse(emptyCommandResponse()));
 
       MqRestSession session = basicBuilder().mappingStrict(false).build();
-      session.mqscCommand("DISPLAY", "QUEUE", "*", null, null, "max_depth GT 5000");
+      session.mqscCommand("DISPLAY", "QUEUE", "*", null, null, "max_queue_depth GT 5000");
 
       @SuppressWarnings("unchecked")
       ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
@@ -990,7 +990,7 @@ class MqRestSessionTest {
           .thenReturn(successResponse(emptyCommandResponse()));
 
       MqRestSession session = basicBuilder().mappingStrict(false).build();
-      session.mqscCommand("DISPLAY", "QUEUE", "*", null, null, "max_depth");
+      session.mqscCommand("DISPLAY", "QUEUE", "*", null, null, "max_queue_depth");
 
       @SuppressWarnings("unchecked")
       ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
@@ -1495,7 +1495,7 @@ class MqRestSessionTest {
           .thenReturn(successResponse(emptyCommandResponse()));
 
       MqRestSession session = basicBuilder().mappingStrict(true).build();
-      session.mqscCommand("DISPLAY", "QUEUE", "Q1", null, List.of("max_depth"), null);
+      session.mqscCommand("DISPLAY", "QUEUE", "Q1", null, List.of("max_queue_depth"), null);
 
       @SuppressWarnings("unchecked")
       ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);


### PR DESCRIPTION
## Summary

- Ported all 139 MQSC commands, 50 qualifiers, and ~1,300+ attribute mappings from pymqrest's `mapping_data.py` to `mapping-data.json`
- Updated 6 tests in `MqRestSessionTest` to use real attribute names (`max_queue_depth` instead of stub's `max_depth`
- No code changes needed — the existing  infrastructure handles the full dataset

## Test plan

- [x] [INFO] Scanning for projects...
[INFO] 
[INFO] ---------------< io.github.wphillipmoore:mq-rest-admin >----------------
[INFO] Building mq-rest-admin 0.1.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- spotless:3.2.1:check (spotless-check) @ mq-rest-admin ---
[INFO] Spotless.Java is keeping 62 files clean - 0 needs changes to be clean, 0 were already clean, 62 were skipped because caching determined they were already clean
[INFO] 
[INFO] --- checkstyle:3.6.0:check (checkstyle-check) @ mq-rest-admin ---
[INFO] Starting audit...
[WARN] /Users/pmoore/dev/github/mq-rest-admin/src/main/java/io/github/wphillipmoore/mq/rest/admin/MqRestSession.java:327:5: Distance between variable 'loginUrl' declaration and its first usage is 5, but allowed 3.  Consider making that variable final if you still need to store its value in advance (before method calls that might have side effects on the original value). [VariableDeclarationUsageDistance]
Audit done.
[INFO] You have 0 Checkstyle violations.
[INFO] 
[INFO] --- jacoco:0.8.14:prepare-agent (jacoco-prepare) @ mq-rest-admin ---
[INFO] argLine set to -javaagent:/Users/pmoore/.m2/repository/org/jacoco/org.jacoco.agent/0.8.14/org.jacoco.agent-0.8.14-runtime.jar=destfile=/Users/pmoore/dev/github/mq-rest-admin/target/jacoco.exec
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ mq-rest-admin ---
[INFO] Copying 2 resources from src/main/resources to target/classes
[INFO] 
[INFO] --- compiler:3.14.0:compile (default-compile) @ mq-rest-admin ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ mq-rest-admin ---
[INFO] Copying 1 resource from src/test/resources to target/test-classes
[INFO] 
[INFO] --- compiler:3.14.0:testCompile (default-testCompile) @ mq-rest-admin ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- surefire:3.5.4:test (default-test) @ mq-rest-admin ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running io.github.wphillipmoore.mq.rest.admin.mapping.AttributeMapperTest
[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.503 s -- in io.github.wphillipmoore.mq.rest.admin.mapping.AttributeMapperTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.mapping.MappingOverrideModeTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.032 s -- in io.github.wphillipmoore.mq.rest.admin.mapping.MappingOverrideModeTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.mapping.MappingDataTest
[INFO] Tests run: 47, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.142 s -- in io.github.wphillipmoore.mq.rest.admin.mapping.MappingDataTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.mapping.MappingIssueTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.063 s -- in io.github.wphillipmoore.mq.rest.admin.mapping.MappingIssueTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.mapping.MappingReasonTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in io.github.wphillipmoore.mq.rest.admin.mapping.MappingReasonTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.mapping.MappingDirectionTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in io.github.wphillipmoore.mq.rest.admin.mapping.MappingDirectionTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.mapping.MappingExceptionTest
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 s -- in io.github.wphillipmoore.mq.rest.admin.mapping.MappingExceptionTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.ensure.EnsureActionTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s -- in io.github.wphillipmoore.mq.rest.admin.ensure.EnsureActionTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.ensure.EnsureResultTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 s -- in io.github.wphillipmoore.mq.rest.admin.ensure.EnsureResultTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.auth.LtpaAuthTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s -- in io.github.wphillipmoore.mq.rest.admin.auth.LtpaAuthTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.auth.CredentialsTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s -- in io.github.wphillipmoore.mq.rest.admin.auth.CredentialsTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.auth.BasicAuthTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s -- in io.github.wphillipmoore.mq.rest.admin.auth.BasicAuthTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.auth.CertificateAuthTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.010 s -- in io.github.wphillipmoore.mq.rest.admin.auth.CertificateAuthTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.PackageInfoTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in io.github.wphillipmoore.mq.rest.admin.PackageInfoTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$NullConfigBranch
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.768 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$NullConfigBranch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$InterruptHandling
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.024 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$InterruptHandling
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$SystemClockTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.040 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$SystemClockTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$NamePassedThrough
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.035 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$NamePassedThrough
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$RestartCombinedMetrics
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$RestartCombinedMetrics
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$ChannelErrorStatusMeansStopped
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$ChannelErrorStatusMeansStopped
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$ServiceEmptyStatus
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.010 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$ServiceEmptyStatus
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$LowercaseStatusValues
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.021 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$LowercaseStatusValues
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$SyncMethodDispatch
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.086 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$SyncMethodDispatch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$ConfigHandling
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.021 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$ConfigHandling
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$Restart
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$Restart
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$Timeout
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.021 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$Timeout
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$StopAndPoll
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.043 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$StopAndPoll
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$StartAndPoll
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.030 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$StartAndPoll
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$HasStatus
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.043 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest$HasStatus
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.214 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionSyncTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.TransportResponseTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.021 s -- in io.github.wphillipmoore.mq.rest.admin.TransportResponseTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$MiscellaneousDispatch
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.051 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$MiscellaneousDispatch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$SetDispatch
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.032 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$SetDispatch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$ResumeSuspendDispatch
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$ResumeSuspendDispatch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$ResolveDispatch
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.023 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$ResolveDispatch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$ResetDispatch
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.030 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$ResetDispatch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$RefreshDispatch
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$RefreshDispatch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$ClearDispatch
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$ClearDispatch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$PingDispatch
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$PingDispatch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$StopDispatch
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.038 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$StopDispatch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$StartDispatch
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.035 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$StartDispatch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$DeleteDispatch
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.064 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$DeleteDispatch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$AlterDispatch
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.060 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$AlterDispatch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$DefineDispatch
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.062 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$DefineDispatch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$DisplayOptionalNameDispatch
[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.128 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$DisplayOptionalNameDispatch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$DisplaySingletonDispatch
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$DisplaySingletonDispatch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$DisplayWildcardDispatch
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$DisplayWildcardDispatch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$MappingIntegration
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$MappingIntegration
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$ErrorPropagation
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.016 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$ErrorPropagation
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$ParameterForwarding
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$ParameterForwarding
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$NoNameVoidPattern
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.010 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$NoNameVoidPattern
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$OptionalNameVoidPattern
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$OptionalNameVoidPattern
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$RequiredNamePattern
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.025 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$RequiredNamePattern
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$SingletonDisplayPattern
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.027 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$SingletonDisplayPattern
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$OptionalNameDisplayPattern
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.010 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$OptionalNameDisplayPattern
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$WildcardDisplayPattern
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest$WildcardDisplayPattern
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.727 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionCommandsTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.sync.SyncConfigTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s -- in io.github.wphillipmoore.mq.rest.admin.sync.SyncConfigTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.sync.SyncResultTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in io.github.wphillipmoore.mq.rest.admin.sync.SyncResultTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.sync.SyncOperationTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in io.github.wphillipmoore.mq.rest.admin.sync.SyncOperationTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestTransportTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestTransportTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.exception.MqRestTimeoutExceptionTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in io.github.wphillipmoore.mq.rest.admin.exception.MqRestTimeoutExceptionTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.exception.MqRestAuthExceptionTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in io.github.wphillipmoore.mq.rest.admin.exception.MqRestAuthExceptionTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.exception.MqRestExceptionTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in io.github.wphillipmoore.mq.rest.admin.exception.MqRestExceptionTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.exception.MqRestTransportExceptionTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in io.github.wphillipmoore.mq.rest.admin.exception.MqRestTransportExceptionTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.exception.MqRestCommandExceptionTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in io.github.wphillipmoore.mq.rest.admin.exception.MqRestCommandExceptionTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.exception.MqRestResponseExceptionTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in io.github.wphillipmoore.mq.rest.admin.exception.MqRestResponseExceptionTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$BranchCoverage
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.023 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$BranchCoverage
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$VerifyTls
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$VerifyTls
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$MappingOverrides
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$MappingOverrides
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$CommandNormalization
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$CommandNormalization
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$TimeoutConfiguration
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$TimeoutConfiguration
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$MissingCommandResponse
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$MissingCommandResponse
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$WhereWithMapping
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$WhereWithMapping
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$StaticHelpers
[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.028 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$StaticHelpers
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$WhereMapping
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$WhereMapping
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$ResponseParameterMapping
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.024 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$ResponseParameterMapping
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$QualifierResolution
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$QualifierResolution
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$AttributeMappingIntegration
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$AttributeMappingIntegration
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$NestedObjectFlattening
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$NestedObjectFlattening
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$ErrorDetection
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$ErrorDetection
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$ResponseParsing
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$ResponseParsing
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$SessionState
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$SessionState
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$MqscCommandFlow
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.023 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$MqscCommandFlow
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$Headers
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$Headers
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$LtpaLogin
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$LtpaLogin
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$BuilderValidation
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.016 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest$BuilderValidation
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.265 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.HttpClientTransportTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.HttpClientTransportTest$ConstructorTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.689 s -- in io.github.wphillipmoore.mq.rest.admin.HttpClientTransportTest$ConstructorTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.HttpClientTransportTest$TrustAllManagerTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s -- in io.github.wphillipmoore.mq.rest.admin.HttpClientTransportTest$TrustAllManagerTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.HttpClientTransportTest$CreateSslContextTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s -- in io.github.wphillipmoore.mq.rest.admin.HttpClientTransportTest$CreateSslContextTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.HttpClientTransportTest$FlattenHeadersTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.010 s -- in io.github.wphillipmoore.mq.rest.admin.HttpClientTransportTest$FlattenHeadersTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.HttpClientTransportTest$ExceptionHandling
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.277 s -- in io.github.wphillipmoore.mq.rest.admin.HttpClientTransportTest$ExceptionHandling
[INFO] Running io.github.wphillipmoore.mq.rest.admin.HttpClientTransportTest$VerifyTlsBranching
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.037 s -- in io.github.wphillipmoore.mq.rest.admin.HttpClientTransportTest$VerifyTlsBranching
[INFO] Running io.github.wphillipmoore.mq.rest.admin.HttpClientTransportTest$PostJsonHappyPath
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.101 s -- in io.github.wphillipmoore.mq.rest.admin.HttpClientTransportTest$PostJsonHappyPath
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.138 s -- in io.github.wphillipmoore.mq.rest.admin.HttpClientTransportTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest$ExtractParametersMap
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.034 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest$ExtractParametersMap
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest$EnsureEdgeCases
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.053 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest$EnsureEdgeCases
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest$EnsureAlterQualifier
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.040 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest$EnsureAlterQualifier
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest$EnsureQualifierDispatch
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.105 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest$EnsureQualifierDispatch
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest$EnsureQmgr
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.030 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest$EnsureQmgr
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest$EnsureObjectUpdated
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.021 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest$EnsureObjectUpdated
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest$EnsureObjectUnchanged
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest$EnsureObjectUnchanged
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest$EnsureObjectCreated
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest$EnsureObjectCreated
[INFO] Running io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest$ValuesMatch
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.049 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest$ValuesMatch
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.375 s -- in io.github.wphillipmoore.mq.rest.admin.MqRestSessionEnsureTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 616, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.14:report (jacoco-report) @ mq-rest-admin ---
[INFO] Loading execution data file /Users/pmoore/dev/github/mq-rest-admin/target/jacoco.exec
[INFO] Analyzed bundle 'mq-rest-admin' with 29 classes
[INFO] 
[INFO] --- jar:3.4.1:jar (default-jar) @ mq-rest-admin ---
[INFO] 
[INFO] --- failsafe:3.5.4:integration-test (default) @ mq-rest-admin ---
[INFO] 
[INFO] --- failsafe:3.5.4:verify (default) @ mq-rest-admin ---
[INFO] No tests to run.
[INFO] 
[INFO] --- jacoco:0.8.14:check (jacoco-check) @ mq-rest-admin ---
[INFO] Loading execution data file /Users/pmoore/dev/github/mq-rest-admin/target/jacoco.exec
[INFO] Analyzed bundle 'mq-rest-admin' with 29 classes
[INFO] All coverage checks have been met.
[INFO] 
[INFO] >>> spotbugs:4.9.8.2:check (spotbugs-check) > :spotbugs @ mq-rest-admin >>>
[INFO] 
[INFO] --- spotbugs:4.9.8.2:spotbugs (spotbugs) @ mq-rest-admin ---
[INFO] Fork Value is true
[INFO] Done SpotBugs Analysis....
[INFO] Skipping com.github.spotbugs:spotbugs-maven-plugin:4.9.8.2:spotbugs report goal
[INFO] 
[INFO] <<< spotbugs:4.9.8.2:check (spotbugs-check) < :spotbugs @ mq-rest-admin <<<
[INFO] 
[INFO] 
[INFO] --- spotbugs:4.9.8.2:check (spotbugs-check) @ mq-rest-admin ---
[INFO] BugInstance size is 0
[INFO] Error size is 0
[INFO] No errors/warnings found
[INFO] 
[INFO] >>> pmd:3.28.0:check (pmd-check) > :pmd @ mq-rest-admin >>>
[INFO] 
[INFO] --- pmd:3.28.0:pmd (pmd) @ mq-rest-admin ---
[INFO] PMD version: 7.17.0
[INFO] Rendering content with org.apache.maven.skins:maven-fluido-skin:jar:2.0.0-M9 skin
[INFO] 
[INFO] <<< pmd:3.28.0:check (pmd-check) < :pmd @ mq-rest-admin <<<
[INFO] 
[INFO] 
[INFO] --- pmd:3.28.0:check (pmd-check) @ mq-rest-admin ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  26.143 s
[INFO] Finished at: 2026-02-13T17:14:54-05:00
[INFO] ------------------------------------------------------------------------ passes (all 616+ tests, Spotless, Checkstyle, SpotBugs, PMD, JaCoCo)
- [ ] Spot-check a few qualifier entries against pymqrest source

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)