### PR TITLE
feat: add GitHub Actions CI workflow with 6-job pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,155 @@
+name: CI - Test and Validate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - 'release/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-only:
+    name: docs-only
+    runs-on: ubuntu-latest
+    outputs:
+      docs-only: ${{ steps.detect.outputs.docs-only }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Detect docs-only changes
+        id: detect
+        uses: wphillipmoore/standard-actions/actions/docs-only-detect@develop
+
+  standards-compliance:
+    name: standards-compliance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate standards
+        uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
+        with:
+          commit-cutoff-sha: "d103713"
+
+  dependency-audit:
+    name: dependency-audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Dependency review (PRs only)
+        if: github.event_name == 'pull_request'
+        uses: actions/dependency-review-action@v4
+
+      - name: Set up Java 17 (push only)
+        if: github.event_name == 'push'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Dependency resolution check (push only)
+        if: github.event_name == 'push'
+        run: ./mvnw dependency:tree -B -q
+
+  release-gates:
+    name: release-gates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip on non-PR events
+        if: github.event_name != 'pull_request'
+        run: echo "Not a pull request; skipping release gates."
+
+      - name: Checkout code
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java 17
+        if: github.event_name == 'pull_request'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: SNAPSHOT gate (PRs targeting main)
+        if: github.event_name == 'pull_request' && github.base_ref == 'main'
+        run: |
+          version=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          if echo "$version" | grep -q -- '-SNAPSHOT'; then
+            echo "FAIL: Version ($version) must not be a SNAPSHOT for releases to main."
+            exit 1
+          fi
+          echo "OK: Version ($version) is not a SNAPSHOT."
+
+      - name: Version divergence gate (PRs targeting develop)
+        if: github.event_name == 'pull_request' && github.base_ref == 'develop'
+        run: |
+          git fetch origin main --depth=1
+          head_version=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          main_pom=$(git show origin/main:pom.xml)
+          main_version=$(echo "$main_pom" | grep -m1 '<version>' | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
+          if [ "$main_version" = "$head_version" ]; then
+            echo "FAIL: PR version ($head_version) must differ from main ($main_version)."
+            exit 1
+          fi
+          echo "OK: PR version ($head_version) differs from main ($main_version)."
+
+  test-and-validate:
+    name: test-and-validate (${{ matrix.java-version }})
+    runs-on: ubuntu-latest
+    needs: docs-only
+    strategy:
+      matrix:
+        java-version: ["17", "21", "25-ea"]
+
+    steps:
+      - name: Docs-only short-circuit
+        if: needs.docs-only.outputs.docs-only == 'true'
+        run: echo "Docs-only changes detected; skipping test-and-validate."
+
+      - name: Checkout code
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: actions/checkout@v4
+
+      - name: Set up Java ${{ matrix.java-version }}
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java-version }}
+          cache: maven
+
+      - name: Run full validation pipeline
+        if: needs.docs-only.outputs.docs-only != 'true'
+        run: ./mvnw verify -B
+
+  integration-tests:
+    name: integration-tests
+    runs-on: ubuntu-latest
+    needs: docs-only
+    steps:
+      - name: Docs-only short-circuit
+        if: needs.docs-only.outputs.docs-only == 'true'
+        run: echo "Docs-only changes detected; skipping integration tests."
+
+      - name: Integration tests pending
+        if: needs.docs-only.outputs.docs-only != 'true'
+        run: |
+          echo "Integration tests are not yet implemented."
+          echo "This job is a placeholder for the required status check."
+          echo "It will be expanded when the integration test strategy is decided."

--- a/docs/plans/open-decisions.md
+++ b/docs/plans/open-decisions.md
@@ -86,6 +86,11 @@ Java port of pymqrest.
 ## CI and publishing
 
 - **CI platform**: GitHub Actions (consistent with pymqrest).
+- **CI workflows**: 6-job pipeline (docs-only, standards-compliance,
+  dependency-audit, release-gates, test-and-validate, integration-tests) with
+  Java 17/21/25 matrix (decided 2026-02-13).
+- **Dependency audit**: `actions/dependency-review-action@v4` (GitHub-native,
+  zero-config) over OWASP Dependency-Check Maven Plugin (decided 2026-02-13).
 - **Publishing target**: Maven Central (implicit from groupId decision).
 - **Publishing mechanism**: Central Portal API (OSSRH shut down June 2025).
 


### PR DESCRIPTION
## Summary

Closes #24

Add a GitHub Actions CI workflow (`.github/workflows/ci.yml`) with 6 jobs
mirroring the pymqrest CI pattern, adapted for Java/Maven:

- **docs-only**: Detects docs-only PRs to short-circuit expensive jobs
- **standards-compliance**: Validates repo profile, markdown, commit messages
- **dependency-audit**: `actions/dependency-review-action@v4` on PRs;
  `./mvnw dependency:tree` on pushes
- **release-gates**: SNAPSHOT gate (PRs to main), version divergence gate
  (PRs to develop)
- **test-and-validate**: Java 17/21/25-ea matrix running `./mvnw verify`
- **integration-tests**: Placeholder for required status check

Also updates `docs/plans/open-decisions.md` to record the CI workflow and
dependency audit decisions.

## Test plan

- [ ] All 6 CI jobs pass on this PR
- [ ] Java 17, 21, and 25 matrix entries pass
- [ ] docs-only detection works (verify via future docs-only PR)
- [ ] After merge, configure required status checks on `develop` branch
  protection