### PR TITLE
fix: add blank line and Table of Contents to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # mq-rest-admin
+
 Java implementation of the IBM MQ administrative REST API wrapper
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Status](#status)
+- [License](#license)
+
+## Overview
+
+A Java port of [pymqrest](https://github.com/wphillipmoore/pymqrest), providing
+a Java wrapper for the IBM MQ administrative REST API. The library uses the
+`runCommandJSON` mode of the MQSC endpoint to execute structured commands and
+translate attributes between Java-friendly names and MQSC parameter names.
+
+## Status
+
+Pre-alpha. Under active development.
+
+## License
+
+[GPLv3](LICENSE)


### PR DESCRIPTION
## Summary

Closes #26

Fixes remaining standards-compliance failures after #27:

- **MD022**: Add blank line after `# mq-rest-admin` heading
- **Missing Table of Contents**: Add required `## Table of Contents` section
- Expand README with Overview, Status, and License sections

Docs-only: tests skipped

Files changed:
- `README.md`

## Test plan

- [ ] standards-compliance job passes
- [ ] All other CI jobs continue to pass