### PR TITLE
feat: add Error Prone, NullAway, and JSpecify null-safety tooling

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/docs/plans/open-decisions.md
+++ b/docs/plans/open-decisions.md
@@ -50,8 +50,9 @@ Java port of pymqrest.
 - **Style checker**: Checkstyle with `google_checks.xml` (decided 2026-02-12).
 - **Bug analysis**: SpotBugs at max effort / low threshold (decided 2026-02-12).
 - **Code smell detection**: PMD with default ruleset (decided 2026-02-12).
-- **Null-safety strategy**: Deferred until API surface takes shape (JSpecify
-  planned).
+- **Null-safety strategy**: JSpecify 1.0.0 adopted for `@Nullable` annotations,
+  enforced by NullAway 0.13.1 at ERROR severity via Error Prone 2.47.0 (JDK
+  21+ only, decided 2026-02-14).
 
 ## Testing
 

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -8,6 +8,8 @@
 - [Local validation](#local-validation)
 - [Tooling requirement](#tooling-requirement)
 - [Merge strategy override](#merge-strategy-override)
+- [Approved domain abbreviations](#approved-domain-abbreviations)
+- [Accepted naming deviations](#accepted-naming-deviations)
 
 ## Pre-flight checklist
 
@@ -56,3 +58,19 @@ Required for daily workflow:
 - Auto-merge commands:
   - Feature PRs: `gh pr merge --auto --squash --delete-branch`
   - Release PRs: `gh pr merge --auto --merge --delete-branch`
+
+## Approved domain abbreviations
+
+Domain-specific abbreviations that are well-established in the IBM MQ ecosystem
+and may be used in identifiers without expansion:
+
+- `qmgr` — queue manager (established MQSC domain term)
+
+## Accepted naming deviations
+
+Identifiers that intentionally diverge from general naming rules for readability
+or domain alignment:
+
+- `MqRestTransport transport` field in `MqRestSession` — the `MqRest` prefix on
+  the type is redundant within the `MqRestSession` class context, so the field
+  uses the shorter `transport` name rather than `mqRestTransport`.

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
         <mockito.version>5.21.0</mockito.version>
         <assertj.version>3.27.6</assertj.version>
 
+        <!-- Static analysis versions (Error Prone profile, JDK 21+) -->
+        <error-prone.version>2.47.0</error-prone.version>
+        <nullaway.version>0.13.1</nullaway.version>
+        <jspecify.version>1.0.0</jspecify.version>
+
         <!-- Plugin versions -->
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
@@ -64,6 +69,11 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>${gson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <version>${jspecify.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -256,4 +266,42 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>error-prone</id>
+            <activation>
+                <jdk>[21,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-XDcompilePolicy=simple</arg>
+                                <arg>--should-stop=ifError=FLOW</arg>
+                                <arg>-Xplugin:ErrorProne
+                                    -XepOpt:NullAway:AnnotatedPackages=io.github.wphillipmoore.mq.rest.admin
+                                    -Xep:NullAway:ERROR</arg>
+                            </compilerArgs>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>com.google.errorprone</groupId>
+                                    <artifactId>error_prone_core</artifactId>
+                                    <version>${error-prone.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>com.uber.nullaway</groupId>
+                                    <artifactId>nullaway</artifactId>
+                                    <version>${nullaway.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/HttpClientTransport.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/HttpClientTransport.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+import org.jspecify.annotations.Nullable;
 
 /**
  * JDK {@link HttpClient}-based implementation of {@link MqRestTransport}.
@@ -29,7 +30,7 @@ public final class HttpClientTransport implements MqRestTransport {
 
   private final Gson gson = new Gson();
   private final HttpClient client;
-  private HttpClient nonVerifyingClient;
+  private @Nullable HttpClient nonVerifyingClient;
 
   /** Creates a transport with a default TLS-verifying {@link HttpClient}. */
   public HttpClientTransport() {
@@ -60,7 +61,7 @@ public final class HttpClientTransport implements MqRestTransport {
       String url,
       Map<String, Object> payload,
       Map<String, String> headers,
-      Duration timeout,
+      @Nullable Duration timeout,
       boolean verifyTls) {
     HttpClient activeClient = verifyTls ? client : getNonVerifyingClient();
     String json = gson.toJson(payload);

--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/MqRestTransport.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/MqRestTransport.java
@@ -2,6 +2,7 @@ package io.github.wphillipmoore.mq.rest.admin;
 
 import java.time.Duration;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Transport interface for MQ REST API HTTP communication.
@@ -27,6 +28,6 @@ public interface MqRestTransport {
       String url,
       Map<String, Object> payload,
       Map<String, String> headers,
-      Duration timeout,
+      @Nullable Duration timeout,
       boolean verifyTls);
 }

--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/auth/CertificateAuth.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/auth/CertificateAuth.java
@@ -1,6 +1,7 @@
 package io.github.wphillipmoore.mq.rest.admin.auth;
 
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Certificate-based (mTLS) authentication credentials for the MQ REST API.
@@ -11,7 +12,7 @@ import java.util.Objects;
  * @param certPath path to the client certificate file, never null
  * @param keyPath path to the private key file, or null if combined with the certificate
  */
-public record CertificateAuth(String certPath, String keyPath) implements Credentials {
+public record CertificateAuth(String certPath, @Nullable String keyPath) implements Credentials {
 
   /** Validates that certPath is non-null. keyPath may be null. */
   public CertificateAuth {

--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/ensure/EnsureResult.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/ensure/EnsureResult.java
@@ -3,6 +3,7 @@ package io.github.wphillipmoore.mq.rest.admin.ensure;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Result of an ensure operation, containing the action taken and the list of attribute names that
@@ -13,7 +14,8 @@ import java.util.Objects;
  *
  * <p>Mirrors pymqrest's {@code EnsureResult} dataclass.
  */
-public record EnsureResult(EnsureAction action, List<String> changed) implements Serializable {
+public record EnsureResult(EnsureAction action, @Nullable List<String> changed)
+    implements Serializable {
 
   /**
    * Creates an ensure result.

--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/exception/MqRestAuthException.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/exception/MqRestAuthException.java
@@ -1,6 +1,7 @@
 package io.github.wphillipmoore.mq.rest.admin.exception;
 
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Thrown when authentication or authorization fails against the MQ REST API.
@@ -11,7 +12,7 @@ import java.util.Objects;
 public final class MqRestAuthException extends MqRestException {
 
   private final String url;
-  private final Integer statusCode;
+  private final @Nullable Integer statusCode;
 
   /**
    * Creates an auth exception.
@@ -20,7 +21,7 @@ public final class MqRestAuthException extends MqRestException {
    * @param url the URL that was being accessed
    * @param statusCode the HTTP status code, or {@code null} if unavailable
    */
-  public MqRestAuthException(String message, String url, Integer statusCode) {
+  public MqRestAuthException(String message, String url, @Nullable Integer statusCode) {
     super(message);
     this.url = Objects.requireNonNull(url, "url");
     this.statusCode = statusCode;
@@ -50,7 +51,7 @@ public final class MqRestAuthException extends MqRestException {
    *
    * @return the status code, or {@code null}
    */
-  public Integer getStatusCode() {
+  public @Nullable Integer getStatusCode() {
     return statusCode;
   }
 }

--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/exception/MqRestCommandException.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/exception/MqRestCommandException.java
@@ -2,6 +2,7 @@ package io.github.wphillipmoore.mq.rest.admin.exception;
 
 import java.util.Map;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Thrown when an MQSC command returns an error response from the MQ REST API.
@@ -12,7 +13,7 @@ import java.util.Objects;
 public final class MqRestCommandException extends MqRestException {
 
   private final Map<String, Object> payload;
-  private final Integer statusCode;
+  private final @Nullable Integer statusCode;
 
   /**
    * Creates a command exception.
@@ -21,7 +22,8 @@ public final class MqRestCommandException extends MqRestException {
    * @param payload the error response payload (defensively copied as unmodifiable)
    * @param statusCode the HTTP status code, or {@code null} if unavailable
    */
-  public MqRestCommandException(String message, Map<String, Object> payload, Integer statusCode) {
+  public MqRestCommandException(
+      String message, Map<String, Object> payload, @Nullable Integer statusCode) {
     super(message);
     this.payload = Map.copyOf(Objects.requireNonNull(payload, "payload"));
     this.statusCode = statusCode;
@@ -56,7 +58,7 @@ public final class MqRestCommandException extends MqRestException {
    *
    * @return the status code, or {@code null}
    */
-  public Integer getStatusCode() {
+  public @Nullable Integer getStatusCode() {
     return statusCode;
   }
 }

--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/exception/MqRestResponseException.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/exception/MqRestResponseException.java
@@ -1,5 +1,7 @@
 package io.github.wphillipmoore.mq.rest.admin.exception;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Thrown when the MQ REST API returns a malformed or unexpected response.
  *
@@ -7,7 +9,7 @@ package io.github.wphillipmoore.mq.rest.admin.exception;
  */
 public final class MqRestResponseException extends MqRestException {
 
-  private final String responseText;
+  private final @Nullable String responseText;
 
   /**
    * Creates a response exception.
@@ -15,7 +17,7 @@ public final class MqRestResponseException extends MqRestException {
    * @param message description of the failure
    * @param responseText the raw response text, or {@code null} if unavailable
    */
-  public MqRestResponseException(String message, String responseText) {
+  public MqRestResponseException(String message, @Nullable String responseText) {
     super(message);
     this.responseText = responseText;
   }
@@ -27,7 +29,7 @@ public final class MqRestResponseException extends MqRestException {
    * @param responseText the raw response text, or {@code null} if unavailable
    * @param cause the underlying cause
    */
-  public MqRestResponseException(String message, String responseText, Throwable cause) {
+  public MqRestResponseException(String message, @Nullable String responseText, Throwable cause) {
     super(message, cause);
     this.responseText = responseText;
   }
@@ -37,7 +39,7 @@ public final class MqRestResponseException extends MqRestException {
    *
    * @return the response text, or {@code null}
    */
-  public String getResponseText() {
+  public @Nullable String getResponseText() {
     return responseText;
   }
 }

--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/mapping/AttributeMapper.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/mapping/AttributeMapper.java
@@ -5,6 +5,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Translates attributes between snake_case Python-style names and MQSC parameter names.
@@ -106,16 +107,15 @@ public final class AttributeMapper {
       String qualifier,
       Map<String, Object> attributes,
       MappingDirection direction,
-      Integer objectIndex,
+      @Nullable Integer objectIndex,
       List<MappingIssue> issues) {
-    if (!data.hasQualifier(qualifier)) {
+    Map<String, Object> qualifierData = data.getQualifierData(qualifier);
+    if (qualifierData == null) {
       issues.add(
           new MappingIssue(
               direction, MappingReason.UNKNOWN_QUALIFIER, qualifier, null, objectIndex, qualifier));
       return new LinkedHashMap<>(attributes);
     }
-
-    Map<String, Object> qualifierData = data.getQualifierData(qualifier);
     Map<String, String> keyMap =
         getStringMap(
             qualifierData,
@@ -179,7 +179,7 @@ public final class AttributeMapper {
   }
 
   @SuppressWarnings("unchecked")
-  private static Object mapKeyValue(
+  private static @Nullable Object mapKeyValue(
       Map<String, Object> keyValueMap, String attrName, String attrValue) {
     Object attrEntry = keyValueMap.get(attrName);
     if (!(attrEntry instanceof Map)) {
@@ -197,7 +197,7 @@ public final class AttributeMapper {
       Object attrValue,
       MappingDirection direction,
       List<MappingIssue> issues,
-      Integer objectIndex,
+      @Nullable Integer objectIndex,
       String qualifier) {
     if (!valueMap.containsKey(attrName)) {
       return attrValue;

--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/mapping/MappingData.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/mapping/MappingData.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Mapping data for attribute translation between snake_case and MQSC parameter names.
@@ -121,7 +122,7 @@ public final class MappingData {
    * @param command the command string (e.g., "DISPLAY QUEUE")
    * @return the qualifier name, or null if the command is unknown
    */
-  public String getQualifierForCommand(String command) {
+  public @Nullable String getQualifierForCommand(String command) {
     Map<String, Object> commands = getCommandsMap();
     if (commands == null) {
       return null;
@@ -217,7 +218,7 @@ public final class MappingData {
    * @return the qualifier data map, or null if the qualifier is unknown
    */
   @SuppressWarnings("unchecked")
-  Map<String, Object> getQualifierData(String qualifier) {
+  @Nullable Map<String, Object> getQualifierData(String qualifier) {
     Map<String, Object> qualifiers = getQualifiersMap();
     if (qualifiers == null) {
       return null;
@@ -237,13 +238,13 @@ public final class MappingData {
   }
 
   @SuppressWarnings("unchecked")
-  private Map<String, Object> getCommandsMap() {
+  private @Nullable Map<String, Object> getCommandsMap() {
     Object commands = data.get("commands");
     return commands instanceof Map ? (Map<String, Object>) commands : null;
   }
 
   @SuppressWarnings("unchecked")
-  private Map<String, Object> getQualifiersMap() {
+  private @Nullable Map<String, Object> getQualifiersMap() {
     Object qualifiers = data.get("qualifiers");
     return qualifiers instanceof Map ? (Map<String, Object>) qualifiers : null;
   }

--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/mapping/MappingIssue.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/mapping/MappingIssue.java
@@ -2,6 +2,7 @@ package io.github.wphillipmoore.mq.rest.admin.mapping;
 
 import java.io.Serializable;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Single mapping issue recorded during attribute translation.
@@ -20,9 +21,9 @@ public record MappingIssue(
     MappingDirection direction,
     MappingReason reason,
     String attributeName,
-    Object attributeValue,
-    Integer objectIndex,
-    String qualifier)
+    @Nullable Object attributeValue,
+    @Nullable Integer objectIndex,
+    @Nullable String qualifier)
     implements Serializable {
 
   /** Validates that required fields are non-null. */

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionCommandsTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionCommandsTest.java
@@ -204,49 +204,49 @@ class MqRestSessionCommandsTest {
     }
 
     @Test
-    void defineQlocalWithNullNameThrowsNpe() {
+    void defineQlocalWithNullNameThrowsNullPointerException() {
       assertThatThrownBy(() -> session.defineQlocal(null, null, null))
           .isInstanceOf(NullPointerException.class)
           .hasMessage("name");
     }
 
     @Test
-    void defineQremoteWithNullNameThrowsNpe() {
+    void defineQremoteWithNullNameThrowsNullPointerException() {
       assertThatThrownBy(() -> session.defineQremote(null, null, null))
           .isInstanceOf(NullPointerException.class)
           .hasMessage("name");
     }
 
     @Test
-    void defineQaliasWithNullNameThrowsNpe() {
+    void defineQaliasWithNullNameThrowsNullPointerException() {
       assertThatThrownBy(() -> session.defineQalias(null, null, null))
           .isInstanceOf(NullPointerException.class)
           .hasMessage("name");
     }
 
     @Test
-    void defineQmodelWithNullNameThrowsNpe() {
+    void defineQmodelWithNullNameThrowsNullPointerException() {
       assertThatThrownBy(() -> session.defineQmodel(null, null, null))
           .isInstanceOf(NullPointerException.class)
           .hasMessage("name");
     }
 
     @Test
-    void defineChannelWithNullNameThrowsNpe() {
+    void defineChannelWithNullNameThrowsNullPointerException() {
       assertThatThrownBy(() -> session.defineChannel(null, null, null))
           .isInstanceOf(NullPointerException.class)
           .hasMessage("name");
     }
 
     @Test
-    void deleteQueueWithNullNameThrowsNpe() {
+    void deleteQueueWithNullNameThrowsNullPointerException() {
       assertThatThrownBy(() -> session.deleteQueue(null, null, null))
           .isInstanceOf(NullPointerException.class)
           .hasMessage("name");
     }
 
     @Test
-    void deleteChannelWithNullNameThrowsNpe() {
+    void deleteChannelWithNullNameThrowsNullPointerException() {
       assertThatThrownBy(() -> session.deleteChannel(null, null, null))
           .isInstanceOf(NullPointerException.class)
           .hasMessage("name");

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionTest.java
@@ -76,28 +76,28 @@ class MqRestSessionTest {
     }
 
     @Test
-    void builderNullRestBaseUrlThrowsNpe() {
+    void builderNullRestBaseUrlThrowsNullPointerException() {
       assertThatThrownBy(() -> new MqRestSession.Builder(null, QMGR, new BasicAuth("u", "p")))
           .isInstanceOf(NullPointerException.class)
           .hasMessage("restBaseUrl");
     }
 
     @Test
-    void builderNullQmgrNameThrowsNpe() {
+    void builderNullQmgrNameThrowsNullPointerException() {
       assertThatThrownBy(() -> new MqRestSession.Builder(BASE_URL, null, new BasicAuth("u", "p")))
           .isInstanceOf(NullPointerException.class)
           .hasMessage("qmgrName");
     }
 
     @Test
-    void builderNullCredentialsThrowsNpe() {
+    void builderNullCredentialsThrowsNullPointerException() {
       assertThatThrownBy(() -> new MqRestSession.Builder(BASE_URL, QMGR, null))
           .isInstanceOf(NullPointerException.class)
           .hasMessage("credentials");
     }
 
     @Test
-    void buildWithoutTransportThrowsNpe() {
+    void buildWithoutTransportThrowsNullPointerException() {
       assertThatThrownBy(
               () -> new MqRestSession.Builder(BASE_URL, QMGR, new BasicAuth("u", "p")).build())
           .isInstanceOf(NullPointerException.class)

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/ensure/EnsureResultTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/ensure/EnsureResultTest.java
@@ -18,7 +18,7 @@ class EnsureResultTest {
   }
 
   @Test
-  void nullActionThrowsNpe() {
+  void nullActionThrowsNullPointerException() {
     assertThatThrownBy(() -> new EnsureResult(null, List.of()))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("action");

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/sync/SyncResultTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/sync/SyncResultTest.java
@@ -16,7 +16,7 @@ class SyncResultTest {
   }
 
   @Test
-  void nullOperationThrowsNpe() {
+  void nullOperationThrowsNullPointerException() {
     assertThatThrownBy(() -> new SyncResult(null, 1, 1.0))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("operation");


### PR DESCRIPTION
## Summary

- Configure Error Prone 2.47.0 + NullAway 0.13.1 in a JDK 21+ Maven profile with `.mvn/jvm.config` module exports, so CI on Java 21/25 enforces null-safety at ERROR severity while Java 17 builds compile normally
- Add JSpecify 1.0.0 dependency and apply `@Nullable` annotations across all 13 production source files for NullAway compliance
- Rename abbreviated variables (`params` → `requestParameters`/`parameters`, `respParams` → `responseParameters`, `attrs` → `attributes`) per naming standard Rule 3
- Rename 13 test methods from `*ThrowsNpe` to `*ThrowsNullPointerException` across 4 test files
- Document approved domain abbreviations (`qmgr`) and accepted naming deviations in `docs/repository-standards.md`
- Update null-safety decision status in `docs/plans/open-decisions.md` from deferred to adopted

Closes #17

## Test plan

- [x] `./mvnw verify` passes locally (616 tests, 100% line + branch coverage, Spotless/Checkstyle/SpotBugs/PMD clean)
- [ ] CI passes on Java 17 (compiles without Error Prone)
- [ ] CI passes on Java 21 (compiles with Error Prone + NullAway at ERROR severity)
- [ ] CI passes on Java 25 (compiles with Error Prone + NullAway at ERROR severity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)