### PR TITLE
feat: wire up CI integration tests with live MQ containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,14 +140,37 @@ jobs:
     name: integration-tests
     runs-on: ubuntu-latest
     needs: docs-only
+    if: needs.docs-only.outputs.docs-only != 'true'
     steps:
       - name: Docs-only short-circuit
         if: needs.docs-only.outputs.docs-only == 'true'
         run: echo "Docs-only changes detected; skipping integration tests."
 
-      - name: Integration tests pending
-        if: needs.docs-only.outputs.docs-only != 'true'
-        run: |
-          echo "Integration tests are not yet implemented."
-          echo "This job is a placeholder for the required status check."
-          echo "It will be expanded when the integration test strategy is decided."
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Checkout mq-dev-environment
+        uses: actions/checkout@v4
+        with:
+          repository: wphillipmoore/mq-dev-environment
+          ref: main
+          path: .mq-dev-environment
+
+      - name: Setup MQ environment
+        uses: ./.mq-dev-environment/.github/actions/setup-mq
+        with:
+          project-name: mq-rest-admin
+          qm1-rest-port: "9453"
+          qm2-rest-port: "9454"
+
+      - name: Run integration tests
+        env:
+          MQ_REST_ADMIN_RUN_INTEGRATION: "1"
+        run: ./mvnw verify -B

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,7 @@
                             </rules>
                             <excludes>
                                 <exclude>**/package-info.class</exclude>
+                                <exclude>**/*IT.class</exclude>
                             </excludes>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## Summary

- Replace placeholder `integration-tests` CI job with real MQ container workflow
- Exclude `*IT.class` from JaCoCo 100% coverage enforcement
- Add `MqRestSessionIT.java` with display, lifecycle, ensure, gateway, and session state tests

Closes #34

## Changes

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | Real integration-tests job: checkout mq-dev-environment, setup-mq composite action (ports 9453/9454), run `./mvnw verify` with `MQ_REST_ADMIN_RUN_INTEGRATION=1` |
| `pom.xml` | Add `**/*IT.class` to JaCoCo excludes |
| `MqRestSessionIT.java` | New integration test file (5 nested test classes) |

### Test categories

| Nested class | Tests | Description |
|---|---|---|
| `DisplayTests` | 9 | Read-only display of seeded objects (qmgr, queues, channels, listener, topic, namelist, process, qstatus) |
| `LifecycleTests` | 9 | Define, display, alter, delete for qlocal, qremote, qalias, qmodel, channel, listener, process, topic, namelist |
| `EnsureTests` | 3 | Idempotent ensure lifecycle (CREATED, UNCHANGED, UPDATED) for qmgr, qlocal, channel |
| `GatewayTests` | 4 | Multi-QM gateway access (QM2 via QM1, QM1 via QM2, queue display, session properties) |
| `SessionStateTests` | 1 | Verifies state accessors populated after command |

## Test plan

- [x] `./mvnw verify -B` passes without env var (ITs skipped, JaCoCo 100% enforced)
- [ ] CI `integration-tests` job starts MQ containers and runs ITs successfully
- [ ] `./mvnw spotless:check` passes (formatting)
- [ ] `./mvnw checkstyle:check` passes (style)

Docs-only: no — CI workflow, pom.xml, and Java test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)