### PR TITLE
fix: sync mapping data with pymqrest and fix response parsing

### DIFF
--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/MqRestSession.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/MqRestSession.java
@@ -285,10 +285,24 @@ public final class MqRestSession {
     // 12. Extract commandResponse
     List<Map<String, Object>> commandResponse = extractCommandResponse(responsePayload);
 
-    // 13. Flatten nested objects
+    // 13. Extract parameters from each commandResponse item
+    List<Map<String, Object>> parameterObjects = new ArrayList<>();
+    for (Map<String, Object> item : commandResponse) {
+      Object parameters = item.get("parameters");
+      if (parameters instanceof Map) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> parametersMap = (Map<String, Object>) parameters;
+        parameterObjects.add(new LinkedHashMap<>(parametersMap));
+      } else {
+        parameterObjects.add(new LinkedHashMap<>());
+      }
+    }
+    commandResponse = parameterObjects;
+
+    // 14. Flatten nested objects
     commandResponse = flattenNestedObjects(commandResponse);
 
-    // 14. Map response attributes if enabled
+    // 15. Map response attributes if enabled
     if (mapAttributes) {
       commandResponse = normalizeAndMapResponse(commandResponse, mappingQualifier);
     }

--- a/src/main/resources/io/github/wphillipmoore/mq/rest/admin/mapping/mapping-data.json
+++ b/src/main/resources/io/github/wphillipmoore/mq/rest/admin/mapping/mapping-data.json
@@ -150,6 +150,18 @@
     "DELETE SUB": {
       "qualifier": "sub"
     },
+    "DELETE QALIAS": {
+      "qualifier": "queue"
+    },
+    "DELETE QLOCAL": {
+      "qualifier": "queue"
+    },
+    "DELETE QMODEL": {
+      "qualifier": "queue"
+    },
+    "DELETE QREMOTE": {
+      "qualifier": "queue"
+    },
     "DELETE TOPIC": {
       "qualifier": "topic"
     },
@@ -907,6 +919,10 @@
         "STATCHL": "channel_statistics",
         "TPNAME": "transaction_program_name",
         "TPROOT": "topic_root",
+        "CHANNEL": "channel_name",
+        "DEFRECON": "default_reconnect",
+        "TMPMODEL": "temporary_model_queue_name",
+        "TMPQPRFX": "temporary_queue_prefix",
         "TRPTYPE": "transport_type",
         "USECLTID": "use_client_id",
         "USEDLQ": "use_dead_letter_queue",
@@ -1008,6 +1024,7 @@
         "BUFSSENT": "buffers_sent",
         "BYTSRCVD": "bytes_received",
         "BYTSSENT": "bytes_sent",
+        "CHANNEL": "channel_name",
         "CHLTYPE": "channel_type",
         "CHSTADA": "channel_start_date",
         "CHSTATI": "channel_start_time",
@@ -1015,7 +1032,9 @@
         "COMPMSG": "message_compression",
         "COMPRATE": "compression_rate",
         "COMPTIME": "compression_time",
+        "CONNAME": "connection_name",
         "CURLUWID": "current_logical_unit_of_work_id",
+        "CURRENT": "current",
         "CURMSGS": "current_messages",
         "CURSEQNO": "current_sequence_number",
         "CURSHCNV": "current_sharing_conversations",
@@ -1058,6 +1077,7 @@
         "STOPREQ": "stop_requested",
         "SUBSTATE": "sub_state",
         "TPROOT": "topic_root",
+        "XMITQ": "transmission_queue_name",
         "XBATCHSZ": "batch_size_indicator",
         "XQMSGSA": "messages_available",
         "XQTIME": "transmission_queue_time"
@@ -1258,6 +1278,24 @@
         "transaction_program_name": "TPNAME",
         "transport_type": "TRPTYPE"
       },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
       "request_value_map": {},
       "response_key_map": {
         "ADAPTER": "adapter",
@@ -1268,12 +1306,14 @@
         "CONTROL": "start_mode",
         "DESCR": "description",
         "IPADDR": "ip_address",
+        "LISTENER": "listener_name",
         "LOCLNAME": "local_name",
         "NTBNAMES": "netbios_names",
         "PORT": "port",
         "SESSIONS": "sessions",
         "SOCKET": "socket",
-        "TPNAME": "transaction_program_name"
+        "TPNAME": "transaction_program_name",
+        "TRPTYPE": "transport_type"
       },
       "response_value_map": {}
     },
@@ -1358,6 +1398,7 @@
         "ALTTIME": "alteration_time",
         "DESCR": "description",
         "NAMCOUNT": "name_count",
+        "NAMELIST": "namelist_name",
         "NAMES": "names"
       },
       "response_value_map": {}
@@ -1416,6 +1457,7 @@
         "APPLTYPE": "application_type",
         "DESCR": "description",
         "ENVRDATA": "environment_data",
+        "PROCESS": "process_name",
         "USERDATA": "user_data"
       },
       "response_value_map": {}
@@ -1804,6 +1846,7 @@
         "STARTDA": "start_date",
         "STARTTI": "start_time",
         "STATUS": "ha_status",
+        "TYPE": "status_type",
         "UNICLUS": "uniform_cluster_name"
       },
       "response_value_map": {}
@@ -1865,6 +1908,7 @@
         "storage_class": "STGCLASS",
         "stream_queue": "STREAMQ",
         "stream_queue_service": "STRMQOS",
+        "target_queue_name": "TARGET",
         "target_type": "TARGTYPE",
         "to_queue_name": "TOQLOCAL",
         "transmission_queue_name": "XMITQ",
@@ -1912,7 +1956,9 @@
       "request_value_map": {
         "default_persistence": {
           "def": "DEF",
-          "not_fixed": "NOTFIXED"
+          "no": "NO",
+          "not_fixed": "NOTFIXED",
+          "yes": "YES"
         }
       },
       "response_key_map": {
@@ -1975,6 +2021,8 @@
         "MONQ": "queue_monitoring",
         "MSGAGE": "oldest_message_age",
         "MSGDLVSQ": "message_delivery_sequence",
+        "NOSHARE": "no_share",
+        "NOTRIGGER": "no_trigger",
         "NPMCLASS": "non_persistent_message_class",
         "OPPROCS": "open_output_count",
         "OTELPCTL": "otel_propagation_control",
@@ -1995,9 +2043,11 @@
         "QMID": "queue_manager_id",
         "QMURID": "queue_manager_unit_of_work_id",
         "QSGDISP": "queue_sharing_group_disposition",
+        "QSVCIEV": "queue_service_interval_event",
         "QSVCINT": "queue_service_interval",
         "QTIME": "on_queue_time",
         "QTYPE": "queue_type",
+        "QUEUE": "queue_name",
         "RETINTVL": "retention_interval",
         "RNAME": "remote_queue_name",
         "RQMNAME": "remote_queue_manager_name",
@@ -2008,11 +2058,13 @@
         "STGCLASS": "storage_class",
         "STREAMQ": "stream_queue",
         "STRMQOS": "stream_queue_service",
+        "TARGET": "target_queue_name",
         "TARGTYPE": "target_type",
         "TASKNO": "task_number",
         "TID": "thread_id",
         "TPIPE": "tpipe_names",
         "TRANSID": "transaction_id",
+        "TYPE": "type",
         "TRIGDATA": "trigger_data",
         "TRIGDPTH": "trigger_depth",
         "TRIGGER": "trigger_control",
@@ -2028,7 +2080,9 @@
       "response_value_map": {
         "DEFPSIST": {
           "DEF": "def",
-          "NOTFIXED": "not_fixed"
+          "NO": "no",
+          "NOTFIXED": "not_fixed",
+          "YES": "yes"
         }
       }
     },
@@ -2068,6 +2122,7 @@
         "QMURID": "queue_manager_unit_of_work_id",
         "QSGDISP": "queue_sharing_group_disposition",
         "QTIME": "on_queue_time",
+        "QUEUE": "queue_name",
         "SET": "open_set",
         "TASKNO": "task_number",
         "TID": "thread_id",
@@ -2413,8 +2468,11 @@
         "NPMSGDLV": "non_persistent_message_delivery",
         "PMSGDLV": "persistent_message_delivery",
         "PROXYSUB": "proxy_subscriptions",
+        "PUB": "publish",
         "PUBSCOPE": "publication_scope",
+        "SUB": "subscribe",
         "SUBSCOPE": "subscription_scope",
+        "TOPIC": "topic_name",
         "TOPICSTR": "topic_string",
         "TYPE": "topic_type",
         "USEDLQ": "use_dead_letter_queue",

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionCommandsTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionCommandsTest.java
@@ -147,7 +147,7 @@ class MqRestSessionCommandsTest {
 
       Map<String, Object> result = session.displayQmgr(null, null);
 
-      assertThat(result).isNotNull().containsKey("parameters");
+      assertThat(result).isNotNull().containsKey("KEY");
     }
 
     @Test

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionEnsureTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionEnsureTest.java
@@ -748,16 +748,16 @@ class MqRestSessionEnsureTest {
     }
 
     @Test
-    void ensureHandlesResponseWithoutParametersWrapper() {
-      // Response item has attributes at top level (no "parameters" sub-object)
-      TransportResponse topLevelResponse =
+    void ensureHandlesResponseWithParametersWrapper() {
+      // Response item has attributes inside "parameters" sub-object (standard API format)
+      TransportResponse wrappedResponse =
           new TransportResponse(
               200,
               "{\"overallCompletionCode\":0,\"overallReasonCode\":0,"
-                  + "\"commandResponse\":[{\"MAXDEPTH\":\"5000\"}]}",
+                  + "\"commandResponse\":[{\"parameters\":{\"MAXDEPTH\":\"5000\"}}]}",
               Map.of());
       when(transport.postJson(anyString(), anyMap(), anyMap(), any(), anyBoolean()))
-          .thenReturn(topLevelResponse);
+          .thenReturn(wrappedResponse);
 
       EnsureResult result = session.ensureQlocal("Q1", Map.of("MAXDEPTH", "5000"));
 

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionIT.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionIT.java
@@ -236,13 +236,13 @@ class MqRestSessionIT {
                   session.defineQlocal(
                       TEST_QLOCAL,
                       Map.of(
-                          "replace", "YES",
-                          "default_persistence", "YES",
+                          "replace", "yes",
+                          "default_persistence", "yes",
                           "description", "dev test qlocal"),
                       null),
               () -> session.displayQueue(TEST_QLOCAL, null, null, null),
               () -> {}, // no alter for qlocal in pymqrest reference
-              () -> session.deleteQueue(TEST_QLOCAL, null, null),
+              () -> session.mqscCommand("DELETE", "QLOCAL", TEST_QLOCAL, null, null, null),
               null),
           new LifecycleCase(
               "qremote",
@@ -251,15 +251,15 @@ class MqRestSessionIT {
                   session.defineQremote(
                       TEST_QREMOTE,
                       Map.of(
-                          "replace", "YES",
+                          "replace", "yes",
                           "remote_queue_name", "DEV.TARGET",
                           "remote_queue_manager_name", QM1_NAME,
-                          "xmit_q_name", "DEV.XMITQ",
+                          "transmission_queue_name", "DEV.XMITQ",
                           "description", "dev test qremote"),
                       null),
               () -> session.displayQueue(TEST_QREMOTE, null, null, null),
               () -> {},
-              () -> session.deleteQueue(TEST_QREMOTE, null, null),
+              () -> session.mqscCommand("DELETE", "QREMOTE", TEST_QREMOTE, null, null, null),
               null),
           new LifecycleCase(
               "qalias",
@@ -268,13 +268,13 @@ class MqRestSessionIT {
                   session.defineQalias(
                       TEST_QALIAS,
                       Map.of(
-                          "replace", "YES",
+                          "replace", "yes",
                           "target_queue_name", "DEV.QLOCAL",
                           "description", "dev test qalias"),
                       null),
               () -> session.displayQueue(TEST_QALIAS, null, null, null),
               () -> {},
-              () -> session.deleteQueue(TEST_QALIAS, null, null),
+              () -> session.mqscCommand("DELETE", "QALIAS", TEST_QALIAS, null, null, null),
               null),
           new LifecycleCase(
               "qmodel",
@@ -283,14 +283,14 @@ class MqRestSessionIT {
                   session.defineQmodel(
                       TEST_QMODEL,
                       Map.of(
-                          "replace", "YES",
+                          "replace", "yes",
                           "definition_type", "TEMPDYN",
-                          "default_share_option", "SHARED",
+                          "default_input_open_option", "SHARED",
                           "description", "dev test qmodel"),
                       null),
               () -> session.displayQueue(TEST_QMODEL, null, null, null),
               () -> {},
-              () -> session.deleteQueue(TEST_QMODEL, null, null),
+              () -> session.mqscCommand("DELETE", "QMODEL", TEST_QMODEL, null, null, null),
               null),
           new LifecycleCase(
               "channel",
@@ -299,7 +299,7 @@ class MqRestSessionIT {
                   session.defineChannel(
                       TEST_CHANNEL,
                       Map.of(
-                          "replace", "YES",
+                          "replace", "yes",
                           "channel_type", "SVRCONN",
                           "transport_type", "TCP",
                           "description", "dev test channel"),
@@ -321,10 +321,10 @@ class MqRestSessionIT {
                   session.defineListener(
                       TEST_LISTENER,
                       Map.of(
-                          "replace", "YES",
+                          "replace", "yes",
                           "transport_type", "TCP",
                           "port", 1416,
-                          "control", "QMGR",
+                          "start_mode", "QMGR",
                           "description", "dev test listener"),
                       null),
               () -> session.displayListener(TEST_LISTENER, null, null, null),
@@ -342,7 +342,7 @@ class MqRestSessionIT {
                   session.defineProcess(
                       TEST_PROCESS,
                       Map.of(
-                          "replace", "YES",
+                          "replace", "yes",
                           "application_id", "/bin/true",
                           "description", "dev test process"),
                       null),
@@ -359,7 +359,7 @@ class MqRestSessionIT {
                   session.defineTopic(
                       TEST_TOPIC,
                       Map.of(
-                          "replace", "YES",
+                          "replace", "yes",
                           "topic_string", "dev/test",
                           "description", "dev test topic"),
                       null),
@@ -376,8 +376,8 @@ class MqRestSessionIT {
                   session.defineNamelist(
                       TEST_NAMELIST,
                       Map.of(
-                          "replace", "YES",
-                          "names", "DEV.QLOCAL",
+                          "replace", "yes",
+                          "names", List.of("DEV.QLOCAL"),
                           "description", "dev test namelist"),
                       null),
               () -> session.displayNamelist(TEST_NAMELIST, null, null, null),
@@ -458,7 +458,8 @@ class MqRestSessionIT {
       MqRestSession nonStrict = buildNonStrictSession();
 
       // Clean up from any prior failed run.
-      silentDelete(() -> nonStrict.deleteQueue(TEST_ENSURE_QLOCAL, null, null));
+      silentDelete(
+          () -> nonStrict.mqscCommand("DELETE", "QLOCAL", TEST_ENSURE_QLOCAL, null, null, null));
 
       try {
         // Create.
@@ -475,7 +476,8 @@ class MqRestSessionIT {
             nonStrict.ensureQlocal(TEST_ENSURE_QLOCAL, Map.of("description", "ensure updated"));
         assertThat(result.action()).isEqualTo(EnsureAction.UPDATED);
       } finally {
-        silentDelete(() -> nonStrict.deleteQueue(TEST_ENSURE_QLOCAL, null, null));
+        silentDelete(
+            () -> nonStrict.mqscCommand("DELETE", "QLOCAL", TEST_ENSURE_QLOCAL, null, null, null));
       }
     }
 

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionTest.java
@@ -698,8 +698,8 @@ class MqRestSessionTest {
           .thenReturn(
               successResponse(
                   "{\"overallCompletionCode\":0,\"overallReasonCode\":0,"
-                      + "\"commandResponse\":[{\"shared\":\"val\","
-                      + "\"objects\":[{\"nested1\":\"a\"},{\"nested2\":\"b\"}]}]}"));
+                      + "\"commandResponse\":[{\"parameters\":{\"shared\":\"val\","
+                      + "\"objects\":[{\"nested1\":\"a\"},{\"nested2\":\"b\"}]}}]}"));
 
       MqRestSession session = buildSessionNoMapping();
       List<Map<String, Object>> result =
@@ -716,7 +716,7 @@ class MqRestSessionTest {
           .thenReturn(
               successResponse(
                   "{\"overallCompletionCode\":0,\"overallReasonCode\":0,"
-                      + "\"commandResponse\":[{\"key\":\"value\"}]}"));
+                      + "\"commandResponse\":[{\"parameters\":{\"key\":\"value\"}}]}"));
 
       MqRestSession session = buildSessionNoMapping();
       List<Map<String, Object>> result =
@@ -751,7 +751,7 @@ class MqRestSessionTest {
           .thenReturn(
               successResponse(
                   "{\"overallCompletionCode\":0,\"overallReasonCode\":0,"
-                      + "\"commandResponse\":[{\"MAXDEPTH\":5000}]}"));
+                      + "\"commandResponse\":[{\"parameters\":{\"MAXDEPTH\":5000}}]}"));
 
       MqRestSession session = basicBuilder().mapAttributes(true).mappingStrict(false).build();
       List<Map<String, Object>> result =
@@ -768,7 +768,7 @@ class MqRestSessionTest {
           .thenReturn(
               successResponse(
                   "{\"overallCompletionCode\":0,\"overallReasonCode\":0,"
-                      + "\"commandResponse\":[{\"MAXDEPTH\":5000}]}"));
+                      + "\"commandResponse\":[{\"parameters\":{\"MAXDEPTH\":5000}}]}"));
 
       MqRestSession session = buildSessionNoMapping();
       List<Map<String, Object>> result =


### PR DESCRIPTION
## Summary

- Sync mapping-data.json with pymqrest authoritative mapping_data.py: add 4 DELETE commands (QALIAS, QLOCAL, QMODEL, QREMOTE), add missing response/request mappings across 9 qualifiers (channel, chstatus, listener, namelist, process, qmstatus, queue, qstatus, topic)
- Fix response parsing bug where completionCode, reasonCode, and the parameters wrapper from the REST API envelope were leaked into MQ attribute results -- now only the parameters contents are returned, matching pymqrest behavior
- Fix integration tests to use correct mapped attribute names and type-specific DELETE qualifiers

## Test plan

- [x] ./mvnw verify -B passes (616 unit tests, 100% coverage, all static analysis clean)
- [x] MQ_REST_ADMIN_RUN_INTEGRATION=1 ./mvnw verify -B passes (34 integration tests against live MQ containers)

Fixes #36