### PR TITLE
docs: enrich documentation pages to match pymqrest depth

### DIFF
--- a/docs/site/docs/ensure-methods.md
+++ b/docs/site/docs/ensure-methods.md
@@ -1,4 +1,4 @@
-# Ensure Methods
+# Declarative Object Management
 
 ## Table of Contents
 
@@ -8,54 +8,106 @@
 
 ## Java usage
 
-### Basic ensure
+### EnsureResult and EnsureAction
 
 ```java
+import io.github.wphillipmoore.mq.rest.admin.ensure.EnsureAction;
 import io.github.wphillipmoore.mq.rest.admin.ensure.EnsureResult;
 
-// Ensure a local queue exists with specific attributes
-EnsureResult result = session.ensureQlocal("MY.QUEUE", Map.of(
-    "max_depth", 10000,
-    "description", "Application queue"
-));
-
-switch (result) {
-    case CREATED -> System.out.println("Queue created");
-    case ALTERED -> System.out.println("Queue updated");
-    case UNCHANGED -> System.out.println("Queue already correct");
-}
+// EnsureAction enum: CREATED, UPDATED, UNCHANGED
+// EnsureResult record: action + changed attribute names
 ```
 
-### Available ensure methods
+### Basic usage
 
-| Method | Object type |
-| --- | --- |
-| `ensureQlocal()` | Local queue |
-| `ensureQremote()` | Remote queue |
-| `ensureQalias()` | Alias queue |
-| `ensureQmodel()` | Model queue |
-| `ensureChannel()` | Channel |
-| `ensureSvrconn()` | Server-connection channel |
-| `ensureTopic()` | Topic |
-| `ensureAuthinfo()` | Authentication info |
-| `ensureListener()` | Listener |
-| `ensureNamelist()` | Namelist |
-| `ensureProcess()` | Process |
-| `ensureService()` | Service |
-| `ensureComminfo()` | Communication info |
-| `ensureStgclass()` | Storage class |
-| `ensureSub()` | Subscription |
-| `ensureQmgr()` | Queue manager (alter only) |
+```java
+// First call — queue does not exist yet
+EnsureResult result = session.ensureQlocal(
+    "APP.REQUEST.Q",
+    Map.of(
+        "max_q_depth", 50000,
+        "description", "Application request queue"
+    )
+);
+assert result.action() == EnsureAction.CREATED;
+
+// Second call — same attributes, nothing to change
+result = session.ensureQlocal(
+    "APP.REQUEST.Q",
+    Map.of(
+        "max_q_depth", 50000,
+        "description", "Application request queue"
+    )
+);
+assert result.action() == EnsureAction.UNCHANGED;
+
+// Third call — description changed, only that attribute is altered
+result = session.ensureQlocal(
+    "APP.REQUEST.Q",
+    Map.of(
+        "max_q_depth", 50000,
+        "description", "Updated request queue"
+    )
+);
+assert result.action() == EnsureAction.UPDATED;
+assert result.changed().contains("description");
+```
 
 ### Queue manager ensure
 
-The queue manager is a singleton that always exists. `ensureQmgr()` only
-supports ALTER (or no-op) and never issues DEFINE:
-
 ```java
 EnsureResult result = session.ensureQmgr(Map.of(
-    "description", "Production queue manager",
-    "max_handles", 1024
+    "statistics_queue", "on",
+    "statistics_channel", "on",
+    "monitoring_queue", "medium",
+    "monitoring_channel", "medium"
 ));
-// result is ALTERED or UNCHANGED, never CREATED
+// result.action() is UPDATED or UNCHANGED, never CREATED
 ```
+
+### Java method signatures
+
+Most ensure methods share the same signature:
+
+```java
+EnsureResult ensureQlocal(String name, Map<String, Object> requestParameters);
+```
+
+The queue manager variant has no name parameter:
+
+```java
+EnsureResult ensureQmgr(Map<String, Object> requestParameters);
+```
+
+### Configuration management example
+
+The ensure pattern is designed for scripts that declare desired state:
+
+```java
+void configureQueueManager(MqRestSession session) {
+    // Ensure queue manager settings
+    EnsureResult result = session.ensureQmgr(Map.of(
+        "statistics_queue", "on",
+        "statistics_channel", "on",
+        "monitoring_queue", "medium",
+        "monitoring_channel", "medium"
+    ));
+    System.out.println("Queue manager: " + result.action());
+
+    // Ensure application queues
+    var queues = Map.of(
+        "APP.REQUEST.Q", Map.of("max_q_depth", 50000, "def_persistence", "yes"),
+        "APP.REPLY.Q", Map.of("max_q_depth", 10000, "def_persistence", "no"),
+        "APP.DLQ", Map.of("max_q_depth", 100000, "def_persistence", "yes")
+    );
+
+    for (var entry : queues.entrySet()) {
+        result = session.ensureQlocal(entry.getKey(), entry.getValue());
+        System.out.println(entry.getKey() + ": " + result.action());
+    }
+}
+```
+
+Running this method repeatedly produces no side effects when the configuration
+is already correct. Only genuine changes trigger `ALTER` commands, keeping
+`ALTDATE`/`ALTTIME` accurate.

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -7,7 +7,11 @@
 - [Creating a session](#creating-a-session)
 - [Running a command](#running-a-command)
 - [Attribute mapping](#attribute-mapping)
+- [Strict vs lenient mapping](#strict-vs-lenient-mapping)
+- [Custom mapping overrides](#custom-mapping-overrides)
+- [Gateway queue manager](#gateway-queue-manager)
 - [Error handling](#error-handling)
+- [Diagnostic state](#diagnostic-state)
 - [Next steps](#next-steps)
 
 ## Prerequisites
@@ -30,6 +34,9 @@ Add the dependency to your `pom.xml`:
 
 ## Creating a session
 
+All interaction with IBM MQ goes through an `MqRestSession`. You need the
+REST API host, port, queue manager name, and credentials:
+
 ```java
 import io.github.wphillipmoore.mq.rest.admin.MqRestSession;
 import io.github.wphillipmoore.mq.rest.admin.auth.BasicAuth;
@@ -38,47 +45,173 @@ var session = MqRestSession.builder()
     .host("localhost")
     .port(9443)
     .queueManager("QM1")
-    .credentials(new BasicAuth("admin", "passw0rd"))
+    .credentials(new BasicAuth("mqadmin", "mqadmin"))
+    .verifyTls(false)  // for local development only
     .build();
 ```
 
 ## Running a command
 
+Every MQSC command has a corresponding method on the session. Method names
+follow the pattern `verbQualifier` in camelCase:
+
 ```java
-// Display all local queues
-var queues = session.displayQueue("*");
+// DISPLAY QUEUE — returns a list of maps
+List<Map<String, Object>> queues = session.displayQueue("SYSTEM.*");
+
 for (var queue : queues) {
-    System.out.println(queue.get("queue_name"));
+    System.out.println(queue.get("queue_name") + " " + queue.get("current_depth"));
+}
+```
+
+```java
+// DISPLAY QMGR — returns a single map or null
+Map<String, Object> qmgr = session.displayQmgr();
+if (qmgr != null) {
+    System.out.println(qmgr.get("queue_manager_name"));
 }
 ```
 
 ## Attribute mapping
 
-By default, the session maps attribute names between Java-friendly `camelCase`
-names and MQSC parameter names:
+By default, the session maps between developer-friendly names and MQSC
+parameter names. This applies to both request and response attributes:
 
 ```java
-// Using mapped names
-var params = Map.of("max_depth", 10000, "description", "My queue");
-session.defineQlocal("MY.QUEUE", params);
+// With mapping enabled (default)
+var queues = session.displayQueue("MY.QUEUE",
+    Map.of("response_parameters", List.of("current_depth", "max_depth")));
+// Returns: [{"queue_name": "MY.QUEUE", "current_depth": 0, "max_depth": 5000}]
 
-// Disable mapping for raw MQSC names
-var rawParams = Map.of("MAXDEPTH", 10000, "DESCR", "My queue");
-session.defineQlocal("MY.QUEUE", rawParams, Map.of("mapAttributes", false));
+// With mapping disabled
+var queues = session.displayQueue("MY.QUEUE",
+    Map.of("response_parameters", List.of("CURDEPTH", "MAXDEPTH")),
+    Map.of("mapAttributes", false));
+// Returns: [{"queue": "MY.QUEUE", "curdepth": 0, "maxdepth": 5000}]
+```
+
+Mapping can be disabled at the session level:
+
+```java
+var session = MqRestSession.builder()
+    .host("localhost")
+    .port(9443)
+    .queueManager("QM1")
+    .credentials(new BasicAuth("mqadmin", "mqadmin"))
+    .mapAttributes(false)
+    .build();
+```
+
+See [Mapping Pipeline](mapping-pipeline.md) for a detailed explanation of how
+mapping works.
+
+## Strict vs lenient mapping
+
+By default, mapping runs in strict mode. Unknown attribute names or values
+raise a `MappingException`. In lenient mode, unknown attributes pass through
+unchanged:
+
+```java
+var session = MqRestSession.builder()
+    .host("localhost")
+    .port(9443)
+    .queueManager("QM1")
+    .credentials(new BasicAuth("mqadmin", "mqadmin"))
+    .mappingStrict(false)
+    .build();
+```
+
+## Custom mapping overrides
+
+Sites with existing naming conventions can override individual entries in the
+built-in mapping tables without replacing them entirely. Pass a
+`mappingOverrides` map when creating the session:
+
+```java
+var session = MqRestSession.builder()
+    .host("localhost")
+    .port(9443)
+    .queueManager("QM1")
+    .credentials(new BasicAuth("mqadmin", "mqadmin"))
+    .mappingOverrides(Map.of(
+        "qualifiers", Map.of(
+            "queue", Map.of(
+                "response_key_map", Map.of(
+                    "CURDEPTH", "queue_depth",      // override built-in mapping
+                    "MAXDEPTH", "queue_max_depth"    // override built-in mapping
+                )
+            )
+        )
+    ))
+    .build();
+
+var queues = session.displayQueue("MY.QUEUE");
+// Returns: [{"queue_depth": 0, "queue_max_depth": 5000, ...}]
+```
+
+Overrides are **sparse** — you only specify the entries you want to change. All
+other mappings in the qualifier continue to work as normal. In the example above,
+only `CURDEPTH` and `MAXDEPTH` are remapped; every other queue attribute keeps
+its default name.
+
+Invalid override structures raise exceptions at session construction time, so
+errors are caught early.
+
+## Gateway queue manager
+
+To route commands to a remote queue manager through a gateway, pass
+`gatewayQmgr` when creating the session. The `queueManager` parameter
+specifies the **target** (remote) queue manager, while `gatewayQmgr` names
+the **local** queue manager whose REST API routes the command:
+
+```java
+// Route commands to QM2 through QM1's REST API
+var session = MqRestSession.builder()
+    .host("qm1-host")
+    .port(9443)
+    .queueManager("QM2")           // target queue manager
+    .credentials(new BasicAuth("mqadmin", "mqadmin"))
+    .gatewayQmgr("QM1")            // local gateway queue manager
+    .build();
+
+var qmgr = session.displayQmgr();
+// Returns QM2's queue manager attributes, routed through QM1
 ```
 
 ## Error handling
 
-```java
-import io.github.wphillipmoore.mq.rest.admin.exception.*;
+`DISPLAY` commands return an empty list when no objects match. Queue manager
+display methods return `null` when no match is found. Non-display commands
+raise `MqRestCommandException` on failure:
 
+```java
+import io.github.wphillipmoore.mq.rest.admin.exception.MqRestCommandException;
+
+// Empty list — no exception
+List<Map<String, Object>> result = session.displayQueue("NONEXISTENT.*");
+assert result.isEmpty();
+
+// Define raises on error
 try {
-    session.displayQueue("NONEXISTENT.QUEUE");
+    session.defineQlocal("MY.QUEUE", Map.of());
 } catch (MqRestCommandException e) {
+    System.out.println(e.getMessage());
     System.out.println("Reason code: " + e.getReasonCode());
-} catch (MqRestTransportException e) {
-    System.out.println("Connection error: " + e.getMessage());
+    System.out.println(e.getCommandResponse());  // full MQ response payload
 }
+```
+
+## Diagnostic state
+
+The session retains the most recent request and response for inspection:
+
+```java
+session.displayQueue("MY.QUEUE");
+
+System.out.println(session.getLastCommandPayload());    // the JSON sent to MQ
+System.out.println(session.getLastResponsePayload());   // the parsed JSON response
+System.out.println(session.getLastHttpStatus());        // HTTP status code
+System.out.println(session.getLastResponseText());      // raw response body
 ```
 
 ## Next steps
@@ -87,3 +220,4 @@ try {
 - [Mapping Pipeline](mapping-pipeline.md) — Learn about attribute translation
 - [API Reference](api/index.md) — Browse the full API
 - [Ensure Methods](ensure-methods.md) — Declarative object management
+- [Sync Methods](sync-methods.md) — Synchronous start/stop/restart


### PR DESCRIPTION
Ref #42

## Summary

- Enrich shared fragments in `mq-rest-admin-common` with detailed explanatory prose from pymqrest docs (problem statements, comparison logic, edge cases, prerequisites)
- Rewrite `ensure-methods.md` with full Java examples: basic usage with assertions, queue manager singleton, method signatures, configuration management example
- Rewrite `getting-started.md` to match pymqrest depth: strict/lenient mapping, custom overrides with sparse examples, gateway queue manager, diagnostic state, richer error handling

Docs-only: tests skipped

Files changed: `docs/site/docs/ensure-methods.md`, `docs/site/docs/getting-started.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)