### PR TITLE
docs: rewrite sync documentation to match actual implementation

### DIFF
--- a/docs/site/docs/api/sync.md
+++ b/docs/site/docs/api/sync.md
@@ -1,51 +1,78 @@
 # Sync
 
-## SyncConfig
+## Overview
 
-Configuration for a bulk sync operation:
-
-```java
-SyncConfig config = SyncConfig.builder()
-    .qualifier("QLOCAL")
-    .desiredState(desiredQueues)
-    .deleteExtras(false)
-    .nameFilter("APP.*")
-    .build();
-```
-
-| Method | Type | Description |
-| --- | --- | --- |
-| `qualifier(String)` | Required | MQSC qualifier to sync (e.g. `"QLOCAL"`) |
-| `desiredState(List)` | Required | List of desired object definitions |
-| `deleteExtras(boolean)` | Optional | Delete objects not in desired list (default: `false`) |
-| `nameFilter(String)` | Optional | Pattern to limit scope of comparison |
-
-## SyncResult
-
-A record containing the results of a sync operation:
-
-```java
-public record SyncResult(
-    int created,
-    int altered,
-    int unchanged,
-    int deleted,
-    List<SyncOperation> operations
-) {}
-```
+The sync package provides the types for the 9 synchronous start/stop/restart
+methods on `MqRestSession`. These methods wrap fire-and-forget `START` and
+`STOP` commands with a polling loop that waits until the object reaches its
+target state or the timeout expires.
 
 ## SyncOperation
 
-Details of a single operation performed during sync:
+An enum indicating the operation that was performed:
 
 ```java
-public record SyncOperation(
-    String name,
-    SyncAction action,
-    Map<String, Object> attributes
+public enum SyncOperation {
+    STARTED,    // Object confirmed running
+    STOPPED,    // Object confirmed stopped
+    RESTARTED   // Stop-then-start completed
+}
+```
+
+## SyncConfig
+
+A record controlling the polling behaviour:
+
+```java
+public record SyncConfig(
+    double timeoutSeconds,       // Max wait before raising (default 30)
+    double pollIntervalSeconds   // Seconds between polls (default 1)
 ) {}
+```
+
+| Method | Return type | Description |
+| --- | --- | --- |
+| `timeoutSeconds()` | `double` | Maximum seconds to wait before raising `MqRestTimeoutException` |
+| `pollIntervalSeconds()` | `double` | Seconds between `DISPLAY *STATUS` polls |
+
+## SyncResult
+
+A record containing the outcome of a sync operation:
+
+```java
+public record SyncResult(
+    SyncOperation operation,   // What happened: STARTED, STOPPED, or RESTARTED
+    int polls,                 // Number of status polls issued
+    double elapsedSeconds      // Wall-clock time from command to confirmation
+) {}
+```
+
+| Method | Return type | Description |
+| --- | --- | --- |
+| `operation()` | `SyncOperation` | What happened: `STARTED`, `STOPPED`, or `RESTARTED` |
+| `polls()` | `int` | Number of status polls issued |
+| `elapsedSeconds()` | `double` | Wall-clock seconds from command to confirmation |
+
+## Method signature pattern
+
+All 9 sync methods follow the same signature pattern:
+
+```java
+SyncResult startChannelSync(String name);
+SyncResult startChannelSync(String name, SyncConfig config);
 ```
 
 ## Usage
 
-See [Sync Methods](../sync-methods.md) for usage examples.
+```java
+SyncResult result = session.startChannelSync("TO.PARTNER");
+
+switch (result.operation()) {
+    case STARTED   -> System.out.println("Running after " + result.polls() + " polls");
+    case STOPPED   -> System.out.println("Stopped");
+    case RESTARTED -> System.out.println("Restarted in " + result.elapsedSeconds() + "s");
+}
+```
+
+See [Sync Methods](../sync-methods.md) for the full conceptual overview,
+polling behaviour, and the complete list of available methods.

--- a/docs/site/docs/sync-methods.md
+++ b/docs/site/docs/sync-methods.md
@@ -1,51 +1,125 @@
-# Sync Methods
+# Synchronous Start/Stop/Restart
 
 --8<-- "concepts/sync-pattern.md"
 
 ## Java usage
 
-### Basic sync
+### SyncConfig, SyncOperation, and SyncResult
 
 ```java
 import io.github.wphillipmoore.mq.rest.admin.sync.SyncConfig;
+import io.github.wphillipmoore.mq.rest.admin.sync.SyncOperation;
 import io.github.wphillipmoore.mq.rest.admin.sync.SyncResult;
 
-var desiredQueues = List.of(
-    Map.of("name", "APP.REQUEST", "max_depth", 10000),
-    Map.of("name", "APP.REPLY", "max_depth", 5000),
-    Map.of("name", "APP.DLQ", "max_depth", 50000)
-);
-
-SyncConfig config = SyncConfig.builder()
-    .qualifier("QLOCAL")
-    .desiredState(desiredQueues)
-    .deleteExtras(false)
-    .nameFilter("APP.*")
-    .build();
-
-SyncResult result = session.sync(config);
-
-System.out.println("Created: " + result.created());
-System.out.println("Altered: " + result.altered());
-System.out.println("Unchanged: " + result.unchanged());
-System.out.println("Deleted: " + result.deleted());
+// SyncOperation enum: STARTED, STOPPED, RESTARTED
+// SyncConfig record: timeoutSeconds (default 30), pollIntervalSeconds (default 1)
+// SyncResult record: operation, polls, elapsedSeconds
 ```
 
-### Delete extras
-
-When `deleteExtras` is `true`, objects that exist on the queue manager but are
-not in the desired state list will be deleted. Use the `nameFilter` to limit
-the scope:
+### Basic start and stop
 
 ```java
-SyncConfig config = SyncConfig.builder()
-    .qualifier("QLOCAL")
-    .desiredState(desiredQueues)
-    .deleteExtras(true)
-    .nameFilter("APP.*")  // only delete APP.* queues not in the list
-    .build();
+// Start a channel and wait until it is RUNNING
+SyncResult result = session.startChannelSync("TO.PARTNER");
+assert result.operation() == SyncOperation.STARTED;
+System.out.println("Channel running after " + result.polls() + " poll(s), "
+    + result.elapsedSeconds() + "s");
+
+// Stop a listener and wait until it is STOPPED
+result = session.stopListenerSync("TCP.LISTENER");
+assert result.operation() == SyncOperation.STOPPED;
 ```
 
-!!! warning
-    Use `deleteExtras` with caution. Always set a `nameFilter` to avoid
-    accidentally deleting system or unrelated objects.
+### Restart convenience
+
+```java
+SyncResult result = session.restartChannel("TO.PARTNER");
+assert result.operation() == SyncOperation.RESTARTED;
+System.out.println("Restarted in " + result.elapsedSeconds() + "s ("
+    + result.polls() + " total polls)");
+```
+
+### Custom timeout and poll interval
+
+Pass a `SyncConfig` to override the defaults:
+
+```java
+// Aggressive polling for fast local development
+SyncConfig fast = new SyncConfig(10, 0.25);
+SyncResult result = session.startServiceSync("MY.SVC", fast);
+
+// Patient polling for remote queue managers
+SyncConfig patient = new SyncConfig(120, 5);
+result = session.startChannelSync("REMOTE.CHL", patient);
+```
+
+### Timeout handling
+
+When the timeout expires, `MqRestTimeoutException` is raised:
+
+```java
+import io.github.wphillipmoore.mq.rest.admin.exception.MqRestTimeoutException;
+
+try {
+    session.startChannelSync(
+        "BROKEN.CHL",
+        new SyncConfig(15, 1)
+    );
+} catch (MqRestTimeoutException e) {
+    System.out.println("Timed out: " + e.getMessage());
+}
+```
+
+`MqRestTimeoutException` extends `MqRestException`, so existing
+`catch (MqRestException e)` handlers will catch it.
+
+### Available methods
+
+| Method | Operation | START/STOP qualifier | Status qualifier |
+| --- | --- | --- | --- |
+| `startChannelSync()` | Start | `CHANNEL` | `CHSTATUS` |
+| `stopChannelSync()` | Stop | `CHANNEL` | `CHSTATUS` |
+| `restartChannel()` | Restart | `CHANNEL` | `CHSTATUS` |
+| `startListenerSync()` | Start | `LISTENER` | `LSSTATUS` |
+| `stopListenerSync()` | Stop | `LISTENER` | `LSSTATUS` |
+| `restartListener()` | Restart | `LISTENER` | `LSSTATUS` |
+| `startServiceSync()` | Start | `SERVICE` | `SVSTATUS` |
+| `stopServiceSync()` | Stop | `SERVICE` | `SVSTATUS` |
+| `restartService()` | Restart | `SERVICE` | `SVSTATUS` |
+
+All methods share the same signature pattern:
+
+```java
+SyncResult startChannelSync(String name);
+SyncResult startChannelSync(String name, SyncConfig config);
+```
+
+The `config` parameter is optional — when omitted, the default `SyncConfig`
+(30-second timeout, 1-second poll interval) is used.
+
+### Provisioning example
+
+The sync methods pair naturally with the [ensure methods](ensure-methods.md)
+for end-to-end provisioning:
+
+```java
+SyncConfig config = new SyncConfig(60, 1);
+
+// Ensure listeners exist for application and admin traffic
+session.ensureListener("APP.LISTENER", Map.of(
+    "transport_type", "TCP",
+    "port", 1415,
+    "start_mode", "MQSVC_CONTROL_Q_MGR"
+));
+session.ensureListener("ADMIN.LISTENER", Map.of(
+    "transport_type", "TCP",
+    "port", 1416,
+    "start_mode", "MQSVC_CONTROL_Q_MGR"
+));
+
+// Start them synchronously
+session.startListenerSync("APP.LISTENER", config);
+session.startListenerSync("ADMIN.LISTENER", config);
+
+System.out.println("Listeners ready");
+```


### PR DESCRIPTION
## Summary

- Rewrote `sync-pattern.md` fragment in mq-rest-admin-common to describe the correct concept: synchronous polling wrappers around fire-and-forget START/STOP commands
- Rewrote `docs/site/docs/sync-methods.md` with fragment include and Java-specific examples (SyncConfig, SyncOperation, SyncResult, 9-method table)
- Rewrote `docs/site/docs/api/sync.md` with correct type definitions and usage examples

The previous documentation described a hallucinated bulk declarative configuration management system that never existed in any implementation. See `docs/research/2026-02-14-sync-hallucination-case-study.md` for forensic analysis.

Fixes #44

## Test plan

- [x] `mkdocs build -f docs/site/mkdocs.yml` passes with `strict: true`
- [x] Fragment resolves via snippets plugin
- [x] Zero hits for hallucinated terms (`desiredState`, `deleteExtras`, `nameFilter`, `session.sync(`, `result.created()`, `result.altered()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)