### PR TITLE
docs: replace BasicAuth with LtpaAuth in examples and remove Next Steps

### DIFF
--- a/docs/site/docs/api/session.md
+++ b/docs/site/docs/api/session.md
@@ -17,13 +17,13 @@ Use the builder pattern:
 
 ```java
 import io.github.wphillipmoore.mq.rest.admin.MqRestSession;
-import io.github.wphillipmoore.mq.rest.admin.auth.BasicAuth;
+import io.github.wphillipmoore.mq.rest.admin.auth.LtpaAuth;
 
 var session = MqRestSession.builder()
     .host("localhost")
     .port(9443)
     .queueManager("QM1")
-    .credentials(new BasicAuth("admin", "passw0rd"))
+    .credentials(new LtpaAuth("admin", "passw0rd"))
     .build();
 ```
 
@@ -56,7 +56,7 @@ var session = MqRestSession.builder()
     .host("localhost")
     .port(9443)
     .queueManager("QM1")
-    .credentials(new BasicAuth("admin", "passw0rd"))
+    .credentials(new LtpaAuth("admin", "passw0rd"))
     .build();
 ```
 
@@ -67,7 +67,7 @@ var session = MqRestSession.builder()
     .host("mq-server.example.com")
     .port(9443)
     .queueManager("QM2")
-    .credentials(new BasicAuth("mqadmin", "mqadmin"))
+    .credentials(new LtpaAuth("mqadmin", "mqadmin"))
     .gatewayQmgr("QM1")
     .mapAttributes(true)
     .mappingStrict(false)

--- a/docs/site/docs/api/transport.md
+++ b/docs/site/docs/api/transport.md
@@ -81,7 +81,7 @@ var session = MqRestSession.builder()
     .host("localhost")
     .port(9443)
     .queueManager("QM1")
-    .credentials(new BasicAuth("admin", "passw0rd"))
+    .credentials(new LtpaAuth("admin", "passw0rd"))
     .transport(mockTransport)
     .build();
 ```

--- a/docs/site/docs/architecture.md
+++ b/docs/site/docs/architecture.md
@@ -73,7 +73,7 @@ var session = MqRestSession.builder()
     .host("localhost")
     .port(9443)
     .queueManager("QM1")
-    .credentials(new BasicAuth("admin", "passw0rd"))
+    .credentials(new LtpaAuth("admin", "passw0rd"))
     .transport(mockTransport)
     .build();
 ```
@@ -99,7 +99,7 @@ var session = MqRestSession.builder()
     .host("qm1-host")
     .port(9443)
     .queueManager("QM2")           // target (remote) queue manager
-    .credentials(new BasicAuth("mqadmin", "mqadmin"))
+    .credentials(new LtpaAuth("mqadmin", "mqadmin"))
     .gatewayQmgr("QM1")            // local gateway queue manager
     .build();
 ```

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -25,13 +25,13 @@ REST API host, port, queue manager name, and credentials:
 
 ```java
 import io.github.wphillipmoore.mq.rest.admin.MqRestSession;
-import io.github.wphillipmoore.mq.rest.admin.auth.BasicAuth;
+import io.github.wphillipmoore.mq.rest.admin.auth.LtpaAuth;
 
 var session = MqRestSession.builder()
     .host("localhost")
     .port(9443)
     .queueManager("QM1")
-    .credentials(new BasicAuth("mqadmin", "mqadmin"))
+    .credentials(new LtpaAuth("mqadmin", "mqadmin"))
     .verifyTls(false)  // for local development only
     .build();
 ```
@@ -83,7 +83,7 @@ var session = MqRestSession.builder()
     .host("localhost")
     .port(9443)
     .queueManager("QM1")
-    .credentials(new BasicAuth("mqadmin", "mqadmin"))
+    .credentials(new LtpaAuth("mqadmin", "mqadmin"))
     .mapAttributes(false)
     .build();
 ```
@@ -102,7 +102,7 @@ var session = MqRestSession.builder()
     .host("localhost")
     .port(9443)
     .queueManager("QM1")
-    .credentials(new BasicAuth("mqadmin", "mqadmin"))
+    .credentials(new LtpaAuth("mqadmin", "mqadmin"))
     .mappingStrict(false)
     .build();
 ```
@@ -118,7 +118,7 @@ var session = MqRestSession.builder()
     .host("localhost")
     .port(9443)
     .queueManager("QM1")
-    .credentials(new BasicAuth("mqadmin", "mqadmin"))
+    .credentials(new LtpaAuth("mqadmin", "mqadmin"))
     .mappingOverrides(Map.of(
         "qualifiers", Map.of(
             "queue", Map.of(
@@ -147,7 +147,7 @@ var session = MqRestSession.builder()
     .host("localhost")
     .port(9443)
     .queueManager("QM1")
-    .credentials(new BasicAuth("mqadmin", "mqadmin"))
+    .credentials(new LtpaAuth("mqadmin", "mqadmin"))
     .verifyTls(false)
     .mappingOverrides(Map.of(
         "qualifiers", Map.of(
@@ -197,7 +197,7 @@ var session = MqRestSession.builder()
     .host("qm1-host")
     .port(9443)
     .queueManager("QM2")           // target queue manager
-    .credentials(new BasicAuth("mqadmin", "mqadmin"))
+    .credentials(new LtpaAuth("mqadmin", "mqadmin"))
     .gatewayQmgr("QM1")            // local gateway queue manager
     .build();
 
@@ -247,11 +247,3 @@ System.out.println(session.getLastResponsePayload());   // the parsed JSON respo
 System.out.println(session.getLastHttpStatus());        // HTTP status code
 System.out.println(session.getLastResponseText());      // raw response body
 ```
-
-## Next steps
-
-- [Architecture](architecture.md) — Understand how the library is organized
-- [Mapping Pipeline](mapping-pipeline.md) — Learn about attribute translation
-- [API Reference](api/index.md) — Browse the full API
-- [Ensure Methods](ensure-methods.md) — Declarative object management
-- [Sync Methods](sync-methods.md) — Synchronous start/stop/restart

--- a/docs/site/docs/mapping-pipeline.md
+++ b/docs/site/docs/mapping-pipeline.md
@@ -164,7 +164,7 @@ var session = MqRestSession.builder()
     .host("localhost")
     .port(9443)
     .queueManager("QM1")
-    .credentials(new BasicAuth("admin", "passw0rd"))
+    .credentials(new LtpaAuth("admin", "passw0rd"))
     .mappingStrict(true)  // default
     .build();
 
@@ -173,7 +173,7 @@ var session = MqRestSession.builder()
     .host("localhost")
     .port(9443)
     .queueManager("QM1")
-    .credentials(new BasicAuth("admin", "passw0rd"))
+    .credentials(new LtpaAuth("admin", "passw0rd"))
     .mappingStrict(false)
     .build();
 ```
@@ -206,7 +206,7 @@ var session = MqRestSession.builder()
     .host("localhost")
     .port(9443)
     .queueManager("QM1")
-    .credentials(new BasicAuth("admin", "passw0rd"))
+    .credentials(new LtpaAuth("admin", "passw0rd"))
     .mappingOverrides(overrides)
     .build();
 
@@ -269,7 +269,7 @@ session-level setting:
 // Session has mapping enabled (default)
 var session = MqRestSession.builder()
     .host("localhost").port(9443).queueManager("QM1")
-    .credentials(new BasicAuth("admin", "passw0rd"))
+    .credentials(new LtpaAuth("admin", "passw0rd"))
     .build();
 
 // This call uses native MQSC names
@@ -285,7 +285,7 @@ Mapping can also be disabled entirely at the session level:
 ```java
 var session = MqRestSession.builder()
     .host("localhost").port(9443).queueManager("QM1")
-    .credentials(new BasicAuth("admin", "passw0rd"))
+    .credentials(new LtpaAuth("admin", "passw0rd"))
     .mapAttributes(false)  // all commands use native MQSC names
     .build();
 ```


### PR DESCRIPTION
## Summary

- Replace `BasicAuth` with `LtpaAuth` in all code examples (getting-started,
  session, architecture, mapping-pipeline, transport pages)
- Remove unnecessary "Next Steps" section from getting-started.md
- BasicAuth documentation in auth.md is unchanged (it documents the type itself)

## Issue Linkage

- Fixes #60
- Ref mq-rest-admin-common#5

## Testing

- `mkdocs build -f docs/site/mkdocs.yml --strict` passes

Docs-only: tests skipped

## Notes

- Part of the cross-library documentation consistency audit