### PR TITLE
chore: remove pull_request trigger from docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-      - develop
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Remove `pull_request` trigger from docs workflow
- Auto-deploy remains on push to `main` (releases) only
- `workflow_dispatch` retained for manual deployments

Fixes #64