### PR TITLE
docs: address cross-library documentation consistency nits

### DIFF
--- a/docs/site/docs/architecture.md
+++ b/docs/site/docs/architecture.md
@@ -104,6 +104,12 @@ var session = MqRestSession.builder()
     .build();
 ```
 
+## Runtime dependencies
+
+The library has a single runtime dependency: Gson (~280KB) for JSON
+serialization. All other functionality uses JDK built-in APIs
+(`java.net.http.HttpClient`, `javax.net.ssl`).
+
 ## Package structure
 
 ```text
@@ -138,3 +144,13 @@ io.github.wphillipmoore.mq.rest.admin.ensure
     EnsureAction            — Enum: CREATED, UPDATED, UNCHANGED
     EnsureResult            — Record: action + changed attribute names
 ```
+
+## Ensure pipeline
+
+See [ensure methods](ensure-methods.md) for details on the idempotent
+create-or-update pipeline.
+
+## Sync pipeline
+
+See [sync methods](sync-methods.md) for details on the synchronous
+polling pipeline.

--- a/docs/site/docs/examples.md
+++ b/docs/site/docs/examples.md
@@ -1,0 +1,126 @@
+# Examples
+
+The `examples/` directory contains practical scripts that demonstrate common
+MQ administration tasks using `mq-rest-admin`. Each example is self-contained
+and can be run against the local Docker environment.
+
+## Prerequisites
+
+Start the multi-queue-manager Docker environment and seed both queue managers:
+
+```bash
+./scripts/dev/mq_start.sh
+./scripts/dev/mq_seed.sh
+```
+
+This starts two queue managers (`QM1` on port 9453, `QM2` on port 9454) on a
+shared Docker network. See [local MQ container](development/local-mq-container.md) for details.
+
+## Health check
+
+Connect to one or more queue managers and check:
+
+- Queue manager attributes via `displayQmgr()`
+- Running status via `displayQmstatus()`
+- Listener definitions via `displayListener()`
+
+```java
+var session = MqRestSession.builder()
+    .host("localhost").port(9453).queueManager("QM1")
+    .credentials(new LtpaAuth("mqadmin", "mqadmin"))
+    .verifyTls(false)
+    .build();
+
+var qmgr = session.displayQmgr();
+System.out.println("Queue manager: " + qmgr.get("queue_manager_name"));
+
+var status = session.displayQmstatus();
+System.out.println("Status: " + status.get("channel_initiator_status"));
+
+var listeners = session.displayListener("*");
+for (var listener : listeners) {
+    System.out.println("Listener: " + listener.get("listener_name")
+        + " port=" + listener.get("port"));
+}
+```
+
+## Queue depth monitor
+
+Display all local queues with their current depth and flag queues
+approaching capacity:
+
+```java
+var queues = session.displayQueue("*");
+
+for (var queue : queues) {
+    var depth = ((Number) queue.get("current_queue_depth")).intValue();
+    var maxDepth = ((Number) queue.get("max_queue_depth")).intValue();
+    var pct = maxDepth > 0 ? (depth * 100 / maxDepth) : 0;
+    var flag = pct > 80 ? " *** HIGH ***" : "";
+    System.out.printf("%-40s %5d / %5d (%d%%)%s%n",
+        queue.get("queue_name"), depth, maxDepth, pct, flag);
+}
+```
+
+## Channel status report
+
+Cross-reference channel definitions with live channel status:
+
+```java
+var channels = session.displayChannel("*");
+var statuses = session.displayChstatus("*");
+
+var runningChannels = statuses.stream()
+    .map(s -> s.get("channel_name"))
+    .collect(Collectors.toSet());
+
+for (var channel : channels) {
+    var name = channel.get("channel_name");
+    var state = runningChannels.contains(name) ? "RUNNING" : "INACTIVE";
+    System.out.println(name + ": " + state);
+}
+```
+
+## Environment provisioner
+
+Demonstrate bulk provisioning across two queue managers using ensure
+methods:
+
+```java
+// Ensure application queues exist on QM1
+session.ensureQlocal("APP.REQUESTS", Map.of(
+    "max_queue_depth", 50000,
+    "default_persistence", "persistent"
+));
+session.ensureQlocal("APP.RESPONSES", Map.of(
+    "max_queue_depth", 50000,
+    "default_persistence", "persistent"
+));
+
+// Ensure listeners are running
+var config = new SyncConfig(60, 1);
+session.startListenerSync("TCP.LISTENER", config);
+
+System.out.println("Environment provisioned");
+```
+
+## Dead letter queue inspector
+
+Inspect the dead letter queue configuration:
+
+```java
+var qmgr = session.displayQmgr();
+var dlqName = (String) qmgr.get("dead_letter_q_name");
+
+if (dlqName != null && !dlqName.isBlank()) {
+    var dlq = session.displayQueue(dlqName);
+    if (!dlq.isEmpty()) {
+        var depth = dlq.get(0).get("current_queue_depth");
+        var maxDepth = dlq.get(0).get("max_queue_depth");
+        System.out.println("DLQ: " + dlqName
+            + " depth=" + depth + " max=" + maxDepth);
+    }
+} else {
+    System.out.println("No dead letter queue configured");
+}
+```

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -17,14 +17,6 @@ native MQSC tokens, and surface errors as structured exceptions.
 - **Zero runtime dependencies** beyond Gson (~280KB)
 - **Transport abstraction** for easy testing with mock transports
 
-## Quick links
-
-- [Getting Started](getting-started.md) — Installation and first session
-- [Architecture](architecture.md) — How the library is organized
-- [Mapping Pipeline](mapping-pipeline.md) — Attribute translation details
-- [API Reference](api/index.md) — Class and method documentation
-- [Javadoc](javadoc.md) — Generated API documentation
-
 ## Build coordinates
 
 ```xml

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -59,18 +59,60 @@ nav:
   - Mapping Pipeline: mapping-pipeline.md
   - Ensure Methods: ensure-methods.md
   - Sync Methods: sync-methods.md
+  - Examples: examples.md
   - API Reference:
       - api/index.md
       - Session: api/session.md
-      - Commands: api/commands.md
       - Authentication: api/auth.md
+      - Commands: api/commands.md
       - Transport: api/transport.md
       - Mapping: api/mapping.md
-      - Exceptions: api/exceptions.md
       - Ensure: api/ensure.md
       - Sync: api/sync.md
+      - Exceptions: api/exceptions.md
   - Mappings:
       - mappings/index.md
+      - apstatus: mappings/apstatus.md
+      - archive: mappings/archive.md
+      - authinfo: mappings/authinfo.md
+      - authrec: mappings/authrec.md
+      - authserv: mappings/authserv.md
+      - cfstatus: mappings/cfstatus.md
+      - cfstruct: mappings/cfstruct.md
+      - channel: mappings/channel.md
+      - chinit: mappings/chinit.md
+      - chlauth: mappings/chlauth.md
+      - chstatus: mappings/chstatus.md
+      - clusqmgr: mappings/clusqmgr.md
+      - cluster: mappings/cluster.md
+      - comminfo: mappings/comminfo.md
+      - conn: mappings/conn.md
+      - entauth: mappings/entauth.md
+      - group: mappings/group.md
+      - indoubt: mappings/indoubt.md
+      - listener: mappings/listener.md
+      - log: mappings/log.md
+      - lsstatus: mappings/lsstatus.md
+      - namelist: mappings/namelist.md
+      - policy: mappings/policy.md
+      - process: mappings/process.md
+      - pubsub: mappings/pubsub.md
+      - qmgr: mappings/qmgr.md
+      - qmstatus: mappings/qmstatus.md
+      - qstatus: mappings/qstatus.md
+      - queue: mappings/queue.md
+      - sbstatus: mappings/sbstatus.md
+      - security: mappings/security.md
+      - service: mappings/service.md
+      - smds: mappings/smds.md
+      - smdsconn: mappings/smdsconn.md
+      - stgclass: mappings/stgclass.md
+      - sub: mappings/sub.md
+      - svstatus: mappings/svstatus.md
+      - topic: mappings/topic.md
+      - topicstr: mappings/topicstr.md
+      - tpstatus: mappings/tpstatus.md
+      - usage: mappings/usage.md
   - Design:
       - design/index.md
       - Rationale: design/rationale.md
@@ -82,4 +124,3 @@ nav:
       - Contributing: development/contributing.md
       - Local MQ Container: development/local-mq-container.md
   - AI Engineering: ai-engineering.md
-  - Javadoc: javadoc.md


### PR DESCRIPTION
## Summary

- Standardize nav ordering with full qualifier mapping listings (42 entries)
- Create examples.md with health check, queue depth monitor, channel status, environment provisioner, and DLQ inspector examples
- Add "Runtime dependencies" section and ensure/sync pipeline links to architecture.md
- Remove Quick Links from home page

## Test plan

- [x] `mkdocs build --strict` passes
- Docs-only: tests skipped

Fixes #66
Ref wphillipmoore/mq-rest-admin-common#18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>