### PR TITLE
chore: trigger dev docs deployment on push to develop

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
   workflow_dispatch:
 
 permissions:
@@ -59,7 +60,7 @@ jobs:
       - name: Determine version
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | sed 's/-SNAPSHOT//' | cut -d. -f1,2)
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "alias=latest" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Add `develop` to docs workflow push trigger
- Use `github.ref` instead of `github.event_name` for version determination
- Push to `main` → x.y release with `latest` alias
- Push to `develop` / `workflow_dispatch` → `dev`

Ref #68

## Test plan

- [ ] Workflow YAML is syntactically valid
- [ ] After merge: push to develop triggers docs workflow and updates `dev` version

🤖 Generated with [Claude Code](https://claude.com/claude-code)