### PR TITLE
fix: correct snippets base_path resolution for fragment includes

### DIFF
--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -49,9 +49,9 @@ markdown_extensions:
       alternate_style: true
   - pymdownx.snippets:
       base_path:
-        - docs
-        - ../../.mq-rest-admin-common/fragments
-        - ../../../mq-rest-admin-common/fragments
+        - .mq-rest-admin-common/fragments
+        - ../mq-rest-admin-common/fragments
+        - docs/site/docs
   - tables
   - toc:
       permalink: true


### PR DESCRIPTION
## Summary

- Fix `pymdownx.snippets` base_path to use CWD-relative paths instead of mkdocs.yml-relative paths
- Resolves duplicate headings and missing fragment content on included pages

Fixes wphillipmoore/mq-rest-admin-common#32

## Test plan

- [x] `mkdocs build -f docs/site/mkdocs.yml --strict` passes
- [x] Fragment content renders correctly (no duplicate headings, descriptive text present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)