### PR TITLE
docs: add quality gates documentation page

### DIFF
--- a/docs/site/docs/development/quality-gates.md
+++ b/docs/site/docs/development/quality-gates.md
@@ -1,0 +1,25 @@
+# Quality gates
+
+--8<-- "development/quality-gates.md"
+
+## Java-specific validation
+
+The Java validation pipeline runs as a single Maven lifecycle:
+
+```bash
+./mvnw verify
+```
+
+This executes in order:
+
+1. **Spotless** — google-java-format formatting check (2-space indent)
+2. **Checkstyle** — `google_checks.xml` style rules
+3. **Compile** — Source compilation
+4. **Surefire** — Unit tests (`*Test.java`)
+5. **Failsafe** — Integration tests (`*IT.java`)
+6. **JaCoCo** — 100% line and branch coverage at BUNDLE level
+7. **SpotBugs** — Bug pattern detection (max effort, low threshold)
+8. **PMD** — Code smell detection
+
+The CI matrix tests against Java 17, 21, and 25-ea with Temurin
+distribution.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -127,4 +127,5 @@ nav:
       - Developer Setup: development/developer-setup.md
       - Contributing: development/contributing.md
       - Local MQ Container: development/local-mq-container.md
+      - Quality Gates: development/quality-gates.md
   - AI Engineering: ai-engineering.md


### PR DESCRIPTION
# Pull Request

## Summary

- Add quality gates page to the docs site under Development, including the shared fragment from mq-rest-admin-common
- Append Java-specific validation pipeline details (Spotless, Checkstyle, Surefire, Failsafe, JaCoCo, SpotBugs, PMD)

## Issue Linkage

- Fixes #76

## Testing

- `mkdocs build -f docs/site/mkdocs.yml --strict` passes
- Docs-only: tests skipped
- Files changed: `docs/site/docs/development/quality-gates.md`, `docs/site/mkdocs.yml`

## Notes

- Shared content pulled from `mq-rest-admin-common` via `--8<-- "development/quality-gates.md"`