### PR TITLE
feat: configure Maven Central publication via Central Portal API

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,11 @@ jobs:
           distribution: temurin
           java-version: "17"
           cache: maven
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Extract version
         id: version
@@ -65,12 +70,13 @@ jobs:
           scan-type: sbom
           output-file: target/mq-rest-admin-${{ steps.version.outputs.version }}.cdx.json
 
-      # TODO: Publish to Maven Central when credentials are configured.
-      # This requires Central Portal API token set as repository secrets.
-      # - name: Publish to Maven Central
-      #   run: ./mvnw deploy -B -DskipTests
-      #   env:
-      #     MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+      - name: Publish to Maven Central
+        if: steps.tag_check.outputs.exists == 'false'
+        run: ./mvnw deploy -B -Prelease -DskipTests
+        env:
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Configure git identity
         if: steps.tag_check.outputs.exists == 'false'
@@ -102,16 +108,23 @@ jobs:
             --notes "$(cat <<'EOF'
           ## Installation
 
-          Maven Central publishing is not yet configured. Use JitPack or build
-          from source:
+          **Maven:**
+          ```xml
+          <dependency>
+              <groupId>io.github.wphillipmoore</groupId>
+              <artifactId>mq-rest-admin</artifactId>
+              <version>${{ steps.version.outputs.version }}</version>
+          </dependency>
+          ```
 
-          ```bash
-          git checkout ${{ steps.version.outputs.tag }}
-          ./mvnw install -B
+          **Gradle:**
+          ```groovy
+          implementation 'io.github.wphillipmoore:mq-rest-admin:${{ steps.version.outputs.version }}'
           ```
 
           ## Links
 
+          - [Maven Central](https://central.sonatype.com/artifact/io.github.wphillipmoore/mq-rest-admin)
           - [Documentation](https://wphillipmoore.github.io/mq-rest-admin-java/)
           EOF
           )" \

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,9 @@
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
         <maven-pmd-plugin.version>3.28.0</maven-pmd-plugin.version>
         <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+        <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
+        <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
     </properties>
 
     <dependencies>
@@ -329,6 +332,77 @@
                                 </configuration>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <!-- Sources JAR -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>${maven-source-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Javadoc JAR -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven-javadoc-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- GPG signing -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Publish to Maven Central via Central Portal -->
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central-publishing-maven-plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
## Summary

- Add `release` Maven profile with `maven-source-plugin`, `maven-javadoc-plugin`, `maven-gpg-plugin`, and `central-publishing-maven-plugin`
- Update publish workflow: GPG key import via `setup-java@v4`, deploy step with `-Prelease`, credential env vars
- Replace "build from source" GitHub Release notes with Maven/Gradle coordinates

## Secrets configured

- `CENTRAL_USERNAME` / `CENTRAL_TOKEN` — Central Portal user token
- `GPG_PRIVATE_KEY` / `GPG_PASSPHRASE` — GPG signing key (published to `keys.openpgp.org` and `keyserver.ubuntu.com`)

## Test plan

- [x] `./mvnw verify -B` passes locally
- [ ] CI passes on this PR
- [ ] After merge to `main`, monitor publish workflow for successful Central Portal deployment
- [ ] Verify artifact at https://central.sonatype.com/artifact/io.github.wphillipmoore/mq-rest-admin

Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)