### PR TITLE
chore: bump version to 1.1.0 to align with Python API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wphillipmoore</groupId>
     <artifactId>mq-rest-admin</artifactId>
-    <version>0.1.0</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>mq-rest-admin</name>


### PR DESCRIPTION
## Summary

- Bump version from `0.1.0` to `1.1.0` to align with the Python `pymqrest` package version

## Test plan

- [ ] CI passes

Ref #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)