### PR TITLE
chore: bump version to 1.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.wphillipmoore</groupId>
     <artifactId>mq-rest-admin</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>jar</packaging>
 
     <name>mq-rest-admin</name>


### PR DESCRIPTION
Automated patch version bump after publishing 1.1.0.

This merges `main` back into `develop` to pick up the release tag and any
other release-branch artifacts, then sets the working version to the next
expected patch release. Change this to a minor or major bump if the next
release warrants it.

Ref #81