### PR TITLE
fix: sync prepare_release.py changelog conflict fix from canonical

### DIFF
--- a/scripts/dev/prepare_release.py
+++ b/scripts/dev/prepare_release.py
@@ -157,11 +157,14 @@ def merge_main(version: str) -> None:
     This prevents CHANGELOG.md merge conflicts by ensuring the release branch
     has main's version of the changelog before git-cliff regenerates it.
     Uses a conventional commit message to satisfy commit-msg hooks.
+    Uses ``-X ours`` to auto-resolve conflicts (only CHANGELOG.md should
+    conflict, and git-cliff regenerates it in the next step).
     """
     print("Merging main into release branch...")
     run_command(("git", "fetch", "origin", "main"))
     run_command((
         "git", "merge", "origin/main",
+        "-X", "ours",
         "-m", f"chore: merge main into release/{version}",
     ))
 


### PR DESCRIPTION
## Summary

- Syncs `prepare_release.py` from the canonical standards-and-conventions repository
- Picks up the `-X ours` merge strategy fix for CHANGELOG.md conflicts during `merge_main()`
- git-cliff regenerates the changelog after the merge, so auto-resolving with ours is safe

Fixes #106