### PR TITLE
chore: update dependencies for 1.1.3 cycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       docs-only: ${{ steps.detect.outputs.docs-only }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect docs-only changes
         id: detect
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -47,10 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
@@ -61,7 +61,7 @@ jobs:
 
       - name: Run license compliance check
         run: >-
-          ./mvnw org.codehaus.mojo:license-maven-plugin:2.6.0:add-third-party
+          ./mvnw org.codehaus.mojo:license-maven-plugin:2.7.0:add-third-party
           -Dlicense.excludedScopes=test
           -Dlicense.failIfWarning=true
           "-Dlicense.includedLicenses=Apache-2.0|Apache 2.0|The Apache License, Version 2.0|MIT License|BSD-2-Clause|BSD-3-Clause|ISC|MPL-2.0|GPL-3.0-or-later"
@@ -77,13 +77,13 @@ jobs:
 
       - name: Checkout code
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Java 17
         if: github.event_name == 'pull_request'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
@@ -130,11 +130,11 @@ jobs:
 
       - name: Checkout code
         if: needs.docs-only.outputs.docs-only != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Java ${{ matrix.java-version }}
         if: needs.docs-only.outputs.docs-only != 'true'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java-version }}
@@ -153,7 +153,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run CodeQL analysis
         uses: wphillipmoore/standard-actions/actions/security/codeql@develop
@@ -169,7 +169,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Trivy vulnerability scan
         uses: wphillipmoore/standard-actions/actions/security/trivy@develop
@@ -185,7 +185,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Semgrep SAST scan
         uses: wphillipmoore/standard-actions/actions/security/semgrep@develop
@@ -203,17 +203,17 @@ jobs:
         run: echo "Docs-only changes detected; skipping integration tests."
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
           cache: maven
 
       - name: Checkout mq-dev-environment
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: wphillipmoore/mq-dev-environment
           ref: develop

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,26 +20,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Checkout mq-rest-admin-common
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: wphillipmoore/mq-rest-admin-common
           ref: develop
           path: .mq-rest-admin-common
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
           cache: maven
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
@@ -59,7 +59,7 @@ jobs:
 
       - name: Attest build provenance
         if: steps.tag_check.outputs.exists == 'false'
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v3
         with:
           subject-path: "target/*.jar"
 
@@ -132,7 +132,7 @@ jobs:
 
       - name: Set up Python 3
         if: steps.tag_check.outputs.exists == 'false'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,9 @@
         <gson.version>2.13.2</gson.version>
 
         <!-- Test dependency versions -->
-        <junit-jupiter.version>5.14.2</junit-jupiter.version>
+        <junit-jupiter.version>5.14.3</junit-jupiter.version>
         <mockito.version>5.21.0</mockito.version>
-        <assertj.version>3.27.6</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
 
         <!-- Static analysis versions (Error Prone profile, JDK 21+) -->
         <error-prone.version>2.47.0</error-prone.version>


### PR DESCRIPTION
## Summary

- Update test dependencies: junit-jupiter 5.14.2→5.14.3, assertj-core 3.27.6→3.27.7
- Update CI actions: checkout v4→v6, setup-java v4→v5, setup-python v5→v6, attest-build-provenance v2→v3
- Update CI toolchain: license-maven-plugin 2.6.0→2.7.0

## Test plan

- [ ] CI validation passes on all Java versions (17, 21, 25-ea)
- [ ] All security scans pass
- [ ] Standards compliance passes

Ref #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)