### PR TITLE
chore: update dependencies for 1.1.4 cycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <gson.version>2.13.2</gson.version>
 
         <!-- Test dependency versions -->
-        <junit-jupiter.version>5.14.3</junit-jupiter.version>
+        <junit-jupiter.version>6.0.3</junit-jupiter.version>
         <mockito.version>5.21.0</mockito.version>
         <assertj.version>3.27.7</assertj.version>
 
@@ -54,7 +54,7 @@
         <jspecify.version>1.0.0</jspecify.version>
 
         <!-- Plugin versions -->
-        <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.5.4</maven-failsafe-plugin.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>


### PR DESCRIPTION
## Summary

- Update maven-compiler-plugin 3.14.1 → 3.15.0
- Update JUnit Jupiter 5.14.3 → 6.0.3 (major version, all tests pass)
- All other library deps, plugins, and CI action pins confirmed at latest stable versions

## Test plan

- [x] `./mvnw clean verify` passes locally (100% coverage, SpotBugs/PMD clean)
- [ ] CI passes on all Java versions (17, 21, 25-ea)

Ref #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)