### PR TITLE
feat: use GitHub App token for bump PR to trigger CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -162,10 +162,18 @@ jobs:
             echo "needed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Generate app token for bump PR
+        if: steps.tag_check.outputs.exists == 'false' && steps.bump_check.outputs.needed == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create version bump PR
         if: steps.tag_check.outputs.exists == 'false' && steps.bump_check.outputs.needed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git checkout -b "${{ steps.next_version.outputs.branch }}" origin/develop
           git merge origin/main --no-edit


### PR DESCRIPTION
## Summary

- Replace `github.token` with a GitHub App installation token for the version bump PR step in the publish workflow
- PRs created by `GITHUB_TOKEN` do not trigger workflow runs (GitHub security limitation), so CI never ran on bump PRs
- Uses `actions/create-github-app-token@v1` with `APP_ID` and `APP_PRIVATE_KEY` repository secrets

Fixes #115

See wphillipmoore/standards-and-conventions#196 for the cross-repo tracking issue.

## Test plan

- [ ] Verify `APP_ID` and `APP_PRIVATE_KEY` secrets are configured in repository settings
- [ ] Trigger a publish workflow and confirm the bump PR is created with the App token
- [ ] Confirm CI workflows trigger automatically on the created bump PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
