### PR TITLE
chore: update dependencies for 1.1.5 cycle

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Generate app token for bump PR
         if: steps.tag_check.outputs.exists == 'false' && steps.bump_check.outputs.needed == 'true'
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Update `actions/create-github-app-token` from v1 to v2 in `publish.yml`
- All other dependencies (Gson, JSpecify, JUnit, Mockito, AssertJ, Maven plugins, CI actions, Java runtime pins) verified at latest stable versions — no changes needed

## Dependency audit

| Category | Status |
|---|---|
| Library dependencies (Gson 2.13.2, JSpecify 1.0.0) | Current |
| Test dependencies (JUnit 6.0.3, Mockito 5.21.0, AssertJ 3.27.7) | Current |
| Maven plugins (compiler, surefire, failsafe, JaCoCo, Spotless, Checkstyle, SpotBugs, PMD, javadoc, source, GPG, central-publishing) | Current |
| CI actions (`actions/checkout@v6`, `actions/setup-java@v5`, `actions/setup-python@v6`) | Current |
| CI actions (`actions/create-github-app-token`) | **v1 → v2** |
| Java runtime pins (17, 21, 25-ea) | Current |
| Documentation toolchain (mkdocs-material, mike) | Unpinned (latest) |
| Dependency anchor records | None |

## Test plan

- [x] `./mvnw verify` passes locally

Ref #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)