### PR TITLE
feat: add canonical local validation script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Java wrapper for the IBM MQ administrative REST API, ported from `pymqrest` (Pyt
 ### Build and Validate
 
 ```bash
+scripts/dev/validate_local.sh   # Canonical validation (runs full pipeline below)
 ./mvnw compile              # Compile sources
 ./mvnw verify               # Full pipeline: Spotless → Checkstyle → compile → unit tests →
                             # integration tests → JaCoCo (100% line+branch) → SpotBugs → PMD

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -30,12 +30,26 @@
 - branching_model: library-release
 - release_model: artifact-publishing
 - supported_release_lines: current and previous
+- canonical_local_validation_command: scripts/dev/validate_local.sh
 
 ## Local validation
+
+Canonical local validation command:
+
+```bash
+scripts/dev/validate_local.sh
+```
+
+Individual checks (run by the validation script):
 
 ```bash
 ./mvnw verify           # Full validation pipeline (formatting, style, compile,
                         # tests, coverage, SpotBugs, PMD)
+```
+
+Other useful commands:
+
+```bash
 ./mvnw clean verify     # Clean full validation
 ./mvnw compile          # Compile only
 ./mvnw test             # Unit tests only

--- a/scripts/dev/validate_local.sh
+++ b/scripts/dev/validate_local.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Local validation script mirroring CI hard gates.
+# See: https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/repository/local-validation-scripts.md
+
+set -euo pipefail
+
+# --- Prerequisite checks ---
+
+missing=()
+
+if ! command -v java &>/dev/null; then
+    missing+=("java")
+fi
+
+if [[ ! -x ./mvnw ]]; then
+    missing+=("./mvnw (Maven Wrapper)")
+fi
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "ERROR: Missing required tools: ${missing[*]}" >&2
+    echo "Install with:" >&2
+    for tool in "${missing[@]}"; do
+        case "$tool" in
+            java)  echo "  brew install openjdk@17  (or use SDKMAN)" >&2 ;;
+            *)     echo "  Maven Wrapper should be checked into the repo" >&2 ;;
+        esac
+    done
+    exit 1
+fi
+
+# --- Validation steps ---
+
+run() {
+    echo "Running: $*"
+    "$@"
+}
+
+run ./mvnw verify -B


### PR DESCRIPTION
## Summary

- Add `scripts/dev/validate_local.sh` — checks prerequisites (`java`, `./mvnw`) and runs `./mvnw verify` as a single fail-fast command
- Add `canonical_local_validation_command` to repository profile
- Update CLAUDE.md to reference the canonical script

Fixes #127

## Test plan

- [ ] Run `scripts/dev/validate_local.sh` with prerequisites present — passes
- [ ] Remove `java` from PATH — script exits with actionable error before running any checks
- [ ] CI passes
