### PR TITLE
feat: add shared tooling sync from standard-tooling v1.0.0

### DIFF
--- a/scripts/dev/finalize_repo.sh
+++ b/scripts/dev/finalize_repo.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Finalize a repository after a PR merge: switch to the target branch,
+# fast-forward pull, delete merged local branches, and prune remotes.
+
+# -- defaults ----------------------------------------------------------------
+
+target_branch="develop"
+dry_run=false
+
+# -- argument parsing --------------------------------------------------------
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Finalize a repository after a PR merge.
+
+Options:
+  --target-branch BRANCH  Target branch to switch to (default: develop)
+  --dry-run               Show what would be done without making changes
+  -h, --help              Show this help message
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target-branch)
+      target_branch="$2"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown option '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+# -- eternal branch detection -----------------------------------------------
+
+repo_root="$(git rev-parse --show-toplevel)"
+profile_file="$repo_root/docs/repository-standards.md"
+branching_model=""
+
+if [[ -f "$profile_file" ]]; then
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^[[:space:]-]*branching_model:[[:space:]]*(.+)$ ]]; then
+      branching_model="${BASH_REMATCH[1]}"
+      break
+    fi
+  done < "$profile_file"
+fi
+
+# Build the list of eternal branches to protect from deletion.
+eternal_branches=("gh-pages")
+
+case "$branching_model" in
+  docs-single-branch)
+    eternal_branches+=("develop")
+    ;;
+  library-release)
+    eternal_branches+=("develop" "main")
+    ;;
+  application-promotion)
+    eternal_branches+=("develop" "release" "main")
+    ;;
+  "")
+    echo "WARNING: branching_model not found; protecting develop and main." >&2
+    eternal_branches+=("develop" "main")
+    ;;
+  *)
+    echo "ERROR: unrecognized branching_model '$branching_model'." >&2
+    exit 1
+    ;;
+esac
+
+is_eternal() {
+  local branch="$1"
+  for eternal in "${eternal_branches[@]}"; do
+    if [[ "$branch" == "$eternal" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# -- helpers -----------------------------------------------------------------
+
+run() {
+  if [[ "$dry_run" == true ]]; then
+    echo "  [dry-run] $*"
+  else
+    "$@"
+  fi
+}
+
+# -- step 1: switch to target branch ----------------------------------------
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [[ "$current_branch" != "$target_branch" ]]; then
+  echo "Switching to $target_branch..."
+  run git checkout "$target_branch"
+else
+  echo "Already on $target_branch."
+fi
+
+# -- step 2: fetch and fast-forward pull ------------------------------------
+
+echo "Pulling latest from origin/$target_branch..."
+run git fetch origin "$target_branch"
+if [[ "$dry_run" != true ]]; then
+  git pull --ff-only origin "$target_branch"
+else
+  echo "  [dry-run] git pull --ff-only origin $target_branch"
+fi
+
+# -- step 3: delete merged local branches -----------------------------------
+
+echo "Checking for merged local branches..."
+deleted_branches=()
+
+for branch in $(git branch --merged "$target_branch" --format='%(refname:short)'); do
+  if is_eternal "$branch"; then
+    continue
+  fi
+  echo "  Deleting merged branch: $branch"
+  run git branch -d "$branch"
+  deleted_branches+=("$branch")
+done
+
+# -- step 4: prune stale remote-tracking references -------------------------
+
+echo "Pruning stale remote-tracking references..."
+run git remote prune origin
+
+# -- summary -----------------------------------------------------------------
+
+echo ""
+echo "Finalization complete."
+echo "  Branch: $target_branch"
+if [[ ${#deleted_branches[@]} -gt 0 ]]; then
+  echo "  Deleted: ${deleted_branches[*]}"
+else
+  echo "  Deleted: (none)"
+fi
+echo "  Remotes: pruned"

--- a/scripts/dev/sync-tooling.sh
+++ b/scripts/dev/sync-tooling.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# sync-tooling.sh — keep local copies of shared scripts in sync with
+# the canonical versions in the standard-tooling repository.
+#
+# Usage:
+#   sync-tooling.sh [--check | --fix] [--ref TAG] [--actions-compat]
+#
+# --check           Compare local copies against standard-tooling (default)
+# --fix             Overwrite local copies with canonical versions
+# --ref TAG         Standard-tooling tag to sync to (default: latest tag)
+# --actions-compat  Also sync lint scripts to actions/standards-compliance/scripts/
+
+TOOLING_REPO="https://github.com/wphillipmoore/standard-tooling.git"
+
+# Managed files — paths relative to the repo root.
+MANAGED_FILES=(
+  scripts/git-hooks/commit-msg
+  scripts/git-hooks/pre-commit
+  scripts/lint/co-author.sh
+  scripts/lint/commit-message.sh
+  scripts/lint/commit-messages.sh
+  scripts/lint/markdown-standards.sh
+  scripts/lint/pr-issue-linkage.sh
+  scripts/lint/repo-profile.sh
+  scripts/dev/prepare_release.py
+  scripts/dev/finalize_repo.sh
+  scripts/dev/sync-tooling.sh
+)
+
+# Lint scripts that also get copied to the actions path.
+ACTIONS_LINT_FILES=(
+  scripts/lint/commit-messages.sh
+  scripts/lint/markdown-standards.sh
+  scripts/lint/pr-issue-linkage.sh
+  scripts/lint/repo-profile.sh
+)
+ACTIONS_SCRIPTS_DIR="actions/standards-compliance/scripts"
+
+# -- argument parsing --------------------------------------------------------
+
+mode="check"
+ref=""
+actions_compat=false
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Keep local copies of shared scripts in sync with standard-tooling.
+
+Options:
+  --check           Compare local copies (default)
+  --fix             Overwrite local copies with canonical versions
+  --ref TAG         Standard-tooling tag to sync to (default: latest tag)
+  --actions-compat  Also sync lint scripts to actions/standards-compliance/scripts/
+  -h, --help        Show this help message
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      mode="check"
+      shift
+      ;;
+    --fix)
+      mode="fix"
+      shift
+      ;;
+    --ref)
+      ref="$2"
+      shift 2
+      ;;
+    --actions-compat)
+      actions_compat=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown option '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+# -- resolve repo root -------------------------------------------------------
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+# -- clone canonical source ---------------------------------------------------
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+if [[ -n "$ref" ]]; then
+  clone_ref="$ref"
+else
+  # Discover the latest tag without a full clone.
+  clone_ref="$(git ls-remote --tags --sort=-v:refname "$TOOLING_REPO" 'v*' \
+    | head -n 1 | sed 's|.*refs/tags/||')"
+  if [[ -z "$clone_ref" ]]; then
+    echo "ERROR: no tags found in $TOOLING_REPO" >&2
+    exit 1
+  fi
+fi
+
+echo "Syncing against standard-tooling @ $clone_ref"
+git clone --depth 1 --branch "$clone_ref" "$TOOLING_REPO" "$tmpdir/standard-tooling" 2>/dev/null
+
+canonical="$tmpdir/standard-tooling"
+
+# -- self-update check -------------------------------------------------------
+
+self_path="scripts/dev/sync-tooling.sh"
+self_local="$repo_root/$self_path"
+self_canonical="$canonical/$self_path"
+
+if [[ -f "$self_canonical" && -f "$self_local" ]]; then
+  if ! diff -q "$self_local" "$self_canonical" >/dev/null 2>&1; then
+    if [[ "$mode" == "fix" ]]; then
+      echo "Updating sync-tooling.sh itself and re-executing..."
+      cp "$self_canonical" "$self_local"
+      chmod +x "$self_local"
+      # Re-exec with the same arguments.
+      exec "$self_local" --fix ${ref:+--ref "$ref"} ${actions_compat:+--actions-compat}
+    else
+      echo "STALE: $self_path"
+    fi
+  fi
+fi
+
+# -- compare / fix -----------------------------------------------------------
+
+stale=0
+
+for file in "${MANAGED_FILES[@]}"; do
+  local_file="$repo_root/$file"
+  canonical_file="$canonical/$file"
+
+  # Skip files that don't exist in canonical (repo-specific scripts).
+  if [[ ! -f "$canonical_file" ]]; then
+    continue
+  fi
+
+  if [[ ! -f "$local_file" ]]; then
+    if [[ "$mode" == "fix" ]]; then
+      echo "ADDING: $file"
+      mkdir -p "$(dirname "$local_file")"
+      cp "$canonical_file" "$local_file"
+      chmod --reference="$canonical_file" "$local_file" 2>/dev/null || chmod +x "$local_file"
+    else
+      echo "MISSING: $file"
+      stale=1
+    fi
+    continue
+  fi
+
+  if ! diff -q "$local_file" "$canonical_file" >/dev/null 2>&1; then
+    if [[ "$mode" == "fix" ]]; then
+      echo "UPDATING: $file"
+      cp "$canonical_file" "$local_file"
+      chmod --reference="$canonical_file" "$local_file" 2>/dev/null || chmod +x "$local_file"
+    else
+      echo "STALE: $file"
+      stale=1
+    fi
+  fi
+done
+
+# -- actions compat ----------------------------------------------------------
+
+if [[ "$actions_compat" == true ]]; then
+  for file in "${ACTIONS_LINT_FILES[@]}"; do
+    basename="$(basename "$file")"
+    local_file="$repo_root/$ACTIONS_SCRIPTS_DIR/$basename"
+    canonical_file="$canonical/$file"
+
+    if [[ ! -f "$canonical_file" ]]; then
+      continue
+    fi
+
+    if [[ ! -f "$local_file" ]]; then
+      if [[ "$mode" == "fix" ]]; then
+        echo "ADDING (actions): $ACTIONS_SCRIPTS_DIR/$basename"
+        mkdir -p "$(dirname "$local_file")"
+        cp "$canonical_file" "$local_file"
+        chmod --reference="$canonical_file" "$local_file" 2>/dev/null || chmod +x "$local_file"
+      else
+        echo "MISSING (actions): $ACTIONS_SCRIPTS_DIR/$basename"
+        stale=1
+      fi
+      continue
+    fi
+
+    if ! diff -q "$local_file" "$canonical_file" >/dev/null 2>&1; then
+      if [[ "$mode" == "fix" ]]; then
+        echo "UPDATING (actions): $ACTIONS_SCRIPTS_DIR/$basename"
+        cp "$canonical_file" "$local_file"
+        chmod --reference="$canonical_file" "$local_file" 2>/dev/null || chmod +x "$local_file"
+      else
+        echo "STALE (actions): $ACTIONS_SCRIPTS_DIR/$basename"
+        stale=1
+      fi
+    fi
+  done
+fi
+
+# -- result ------------------------------------------------------------------
+
+if [[ "$mode" == "check" ]]; then
+  if [[ $stale -ne 0 ]]; then
+    echo ""
+    echo "Shared scripts are stale. Run 'scripts/dev/sync-tooling.sh --fix' to update."
+    exit 1
+  else
+    echo "All shared scripts are up to date."
+  fi
+else
+  echo "Sync complete."
+fi

--- a/scripts/lint/commit-messages.sh
+++ b/scripts/lint/commit-messages.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${1:-}"
+head_ref="${2:-}"
+
+if [[ -z "$base_ref" || -z "$head_ref" ]]; then
+  echo "ERROR: base and head refs are required." >&2
+  echo "Usage: commit-messages.sh <base-ref> <head-ref>" >&2
+  exit 2
+fi
+
+# Resolve bare branch names to origin/ when the local branch doesn't exist.
+if ! git rev-parse --verify --quiet "$base_ref" >/dev/null 2>&1; then
+  if git rev-parse --verify --quiet "origin/$base_ref" >/dev/null 2>&1; then
+    base_ref="origin/$base_ref"
+  fi
+fi
+
+conventional_regex='^(feat|fix|docs|style|refactor|test|chore)(\([^\)]+\))?: .+'
+
+# Commits at or before the cutoff SHA predate the conventional commits
+# convention and are excluded from validation.  Consuming repos pass their
+# own cutoff via the COMMIT_CUTOFF_SHA environment variable.
+CUTOFF_SHA="${COMMIT_CUTOFF_SHA:-}"
+
+failed=0
+
+while IFS= read -r commit_sha; do
+  # Skip commits that predate the conventional commits convention.
+  if [[ -n "$CUTOFF_SHA" ]] && git merge-base --is-ancestor "$commit_sha" "$CUTOFF_SHA" 2>/dev/null; then
+    continue
+  fi
+  subject_line="$(git log -n 1 --format=%s "$commit_sha")"
+  if [[ ! "$subject_line" =~ $conventional_regex ]]; then
+    echo "ERROR: commit $commit_sha does not follow Conventional Commits." >&2
+    echo "Expected: <type>(optional-scope): <description>" >&2
+    echo "Allowed types: feat, fix, docs, style, refactor, test, chore" >&2
+    echo "Got: $subject_line" >&2
+    failed=1
+  fi
+  if [[ $failed -ne 0 ]]; then
+    break
+  fi
+done < <(git rev-list --no-merges "${base_ref}..${head_ref}")
+
+exit $failed

--- a/scripts/lint/markdown-standards.sh
+++ b/scripts/lint/markdown-standards.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Collect standard docs (structural checks + markdownlint).
+files=()
+while IFS= read -r file; do
+  files+=("$file")
+done < <(find docs -path docs/sphinx -prune -o -path docs/site -prune -o -path docs/announcements -prune -o -type f -name "*.md" -print)
+
+if [[ -f README.md ]]; then
+  files+=("README.md")
+fi
+
+# Collect doc-site files (markdownlint only — structural checks like
+# Table of Contents and single-H1 do not apply to pages built by
+# documentation site generators such as Sphinx, MkDocs, etc.).
+docsite_files=()
+for docsite_dir in docs/sphinx docs/site; do
+  if [[ -d "$docsite_dir" ]]; then
+    while IFS= read -r file; do
+      docsite_files+=("$file")
+    done < <(find "$docsite_dir" -type f -name "*.md")
+  fi
+done
+
+all_files=("${files[@]}" ${docsite_files[@]+"${docsite_files[@]}"})
+
+# CHANGELOG.md gets markdownlint only — no structural checks (no TOC,
+# multiple H2 headings are expected, heading hierarchy differs).
+if [[ -f CHANGELOG.md ]]; then
+  all_files+=("CHANGELOG.md")
+fi
+
+if [[ ${#all_files[@]} -eq 0 ]]; then
+  echo "ERROR: no markdown files found to lint." >&2
+  exit 2
+fi
+
+if command -v markdownlint >/dev/null 2>&1; then
+  markdownlint_cmd=(markdownlint)
+else
+  echo "ERROR: markdownlint not found. Install markdownlint-cli locally." >&2
+  exit 2
+fi
+
+markdownlint_failed=0
+if [[ -f ".markdownlint.yaml" ]]; then
+  if ! "${markdownlint_cmd[@]}" --config ".markdownlint.yaml" "${all_files[@]}"; then
+    markdownlint_failed=1
+  fi
+else
+  if ! "${markdownlint_cmd[@]}" "${all_files[@]}"; then
+    markdownlint_failed=1
+  fi
+fi
+
+failed=0
+
+for file in "${files[@]}"; do
+  awk -v file="$file" '
+    BEGIN {
+      in_code = 0
+      toc_found = 0
+      h1_count = 0
+      last_level = 0
+      errors = 0
+    }
+    function report(message) {
+      printf "ERROR: %s (%s:%d)\n", message, file, NR > "/dev/stderr"
+      errors = 1
+    }
+    {
+      line = $0
+
+      if (match(line, /^```/) || match(line, /^~~~/)) {
+        in_code = !in_code
+      }
+
+      if (in_code) {
+        next
+      }
+
+      if (line ~ /^## Table of Contents[[:space:]]*$/) {
+        toc_found = 1
+      }
+
+      if (line ~ /^#{1,6} /) {
+        level = length(substr(line, 1, match(line, / /) - 1))
+        if (level == 1) {
+          h1_count += 1
+        }
+        if (last_level > 0 && level > last_level + 1) {
+          report("Heading level skips from " last_level " to " level)
+        }
+        last_level = level
+      }
+    }
+    END {
+      if (h1_count != 1) {
+        printf "ERROR: expected exactly one H1 heading, found %d (%s)\n", h1_count, file > "/dev/stderr"
+        errors = 1
+      }
+      if (toc_found != 1) {
+        printf "ERROR: missing ## Table of Contents (%s)\n", file > "/dev/stderr"
+        errors = 1
+      }
+      exit errors
+    }
+  ' "$file" || failed=1
+
+done
+
+exit $((failed || markdownlint_failed))

--- a/scripts/lint/pr-issue-linkage.sh
+++ b/scripts/lint/pr-issue-linkage.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${GITHUB_EVENT_PATH:-}" ]]; then
+  echo "ERROR: GITHUB_EVENT_PATH is not set." >&2
+  exit 2
+fi
+
+if [[ ! -f "$GITHUB_EVENT_PATH" ]]; then
+  echo "ERROR: event payload not found at $GITHUB_EVENT_PATH" >&2
+  exit 2
+fi
+
+pr_body="$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")"
+
+if [[ -z "$pr_body" ]]; then
+  echo "ERROR: pull request body is empty; issue linkage is required." >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$pr_body" | grep -Eq '^[[:space:]]*[-*]?[[:space:]]*(Fixes|Closes|Resolves|Ref):?[[:space:]]+#[0-9]+'; then
+  echo "ERROR: pull request body must include primary issue linkage (Fixes #123, Closes #123, Resolves #123, or Ref #123)." >&2
+  exit 1
+fi

--- a/scripts/lint/repo-profile.sh
+++ b/scripts/lint/repo-profile.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# Variables are read via indirect expansion (${!key}).
+set -euo pipefail
+
+profile_file="docs/repository-standards.md"
+
+if [[ ! -f "$profile_file" ]]; then
+  echo "ERROR: repository profile file not found at $profile_file" >&2
+  exit 2
+fi
+
+repository_type=""
+versioning_scheme=""
+branching_model=""
+release_model=""
+supported_release_lines=""
+
+while IFS= read -r line; do
+  if [[ "$line" =~ ^[[:space:]-]*repository_type:[[:space:]]*(.+)$ ]]; then
+    repository_type="${BASH_REMATCH[1]}"
+  elif [[ "$line" =~ ^[[:space:]-]*versioning_scheme:[[:space:]]*(.+)$ ]]; then
+    versioning_scheme="${BASH_REMATCH[1]}"
+  elif [[ "$line" =~ ^[[:space:]-]*branching_model:[[:space:]]*(.+)$ ]]; then
+    branching_model="${BASH_REMATCH[1]}"
+  elif [[ "$line" =~ ^[[:space:]-]*release_model:[[:space:]]*(.+)$ ]]; then
+    release_model="${BASH_REMATCH[1]}"
+  elif [[ "$line" =~ ^[[:space:]-]*supported_release_lines:[[:space:]]*(.+)$ ]]; then
+    supported_release_lines="${BASH_REMATCH[1]}"
+  fi
+done < "$profile_file"
+
+failed=0
+
+for key in repository_type versioning_scheme branching_model release_model supported_release_lines; do
+  value="${!key}"
+  if [[ -z "$value" ]]; then
+    echo "ERROR: repository profile missing required attribute '$key' in $profile_file" >&2
+    failed=1
+    continue
+  fi
+
+  if [[ "$value" == *"<"* || "$value" == *">"* || "$value" == *"|"* ]]; then
+    echo "ERROR: repository profile attribute '$key' appears to be a placeholder: $value" >&2
+    failed=1
+  fi
+done
+
+exit $failed


### PR DESCRIPTION
## Summary

- Add sync-tooling.sh from standard-tooling v1.0.0
- Sync all shared scripts (lint, git hooks, dev scripts) to canonical versions
- Adds lint scripts not previously present (commit-messages.sh, markdown-standards.sh, pr-issue-linkage.sh, repo-profile.sh)

## Test plan

- [ ] Verify synced scripts work locally
- [ ] Verify sync-tooling.sh --check passes

Fixes #129

Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
