### PR TITLE
fix: sync shared tooling to v1.0.2

### DIFF
--- a/scripts/dev/sync-tooling.sh
+++ b/scripts/dev/sync-tooling.sh
@@ -42,7 +42,7 @@ ACTIONS_SCRIPTS_DIR="actions/standards-compliance/scripts"
 
 mode="check"
 ref=""
-actions_compat=false
+actions_compat=""
 
 usage() {
   cat <<EOF

--- a/scripts/lint/repo-profile.sh
+++ b/scripts/lint/repo-profile.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034
 # Variables are read via indirect expansion (${!key}).
+# Canonical source: standard-tooling
 set -euo pipefail
 
 profile_file="docs/repository-standards.md"


### PR DESCRIPTION
## Summary

- Sync shared tooling to standard-tooling v1.0.2
- Fix --actions-compat flag leaking during sync-tooling.sh self-update re-exec
- Add canonical source comment to repo-profile.sh

## Test plan

- [x] sync-tooling.sh --check --ref v1.0.2 passes after sync

Fixes #131
