### PR TITLE
docs: rename mq-dev-environment references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,15 +212,15 @@ jobs:
           java-version: "17"
           cache: maven
 
-      - name: Checkout mq-dev-environment
+      - name: Checkout mq-rest-admin-dev-environment
         uses: actions/checkout@v6
         with:
-          repository: wphillipmoore/mq-dev-environment
+          repository: wphillipmoore/mq-rest-admin-dev-environment
           ref: develop
-          path: .mq-dev-environment
+          path: .mq-rest-admin-dev-environment
 
       - name: Setup MQ environment
-        uses: ./.mq-dev-environment/.github/actions/setup-mq
+        uses: ./.mq-rest-admin-dev-environment/.github/actions/setup-mq
         with:
           project-name: mq-rest-admin
           qm1-rest-port: "9453"

--- a/docs/plans/2026-02-14-documentation-architecture.md
+++ b/docs/plans/2026-02-14-documentation-architecture.md
@@ -93,7 +93,7 @@ built-in multi-repo support. However:
 
 **Why CI clone step (not git submodules)**:
 
-- Same pattern already used for `mq-dev-environment` in CI.
+- Same pattern already used for `mq-rest-admin-dev-environment` in CI.
 - Local dev uses sibling directory convention (`../mq-rest-admin-common`).
 - Simpler than submodules (no `.gitmodules`, no recursive clone friction).
 - A helper script creates a symlink for local builds.

--- a/docs/plans/2026-02-14-integration-test-strategy.md
+++ b/docs/plans/2026-02-14-integration-test-strategy.md
@@ -16,12 +16,12 @@
 
 Each consuming project (pymqrest, mq-rest-admin, future Go port) runs distinct
 MQ containers isolated via `COMPOSE_PROJECT_NAME` and project-specific host port
-allocation. Shared Docker infrastructure is provided by the `mq-dev-environment`
+allocation. Shared Docker infrastructure is provided by the `mq-rest-admin-dev-environment`
 repository.
 
 ## Context
 
-The `mq-dev-environment` repo provides shared Docker infrastructure: a
+The `mq-rest-admin-dev-environment` repo provides shared Docker infrastructure: a
 docker-compose.yml with QM1 and QM2, seed scripts for test objects, lifecycle
 scripts (start/seed/verify/stop/reset), and a CI composite action. This is
 already consumed by pymqrest.
@@ -59,7 +59,7 @@ interpolates into the `ports:` mapping.
 ## Local development
 
 Wrapper scripts in `scripts/dev/mq_*.sh` set the project-specific environment
-variables and delegate to the corresponding `mq-dev-environment` scripts:
+variables and delegate to the corresponding `mq-rest-admin-dev-environment` scripts:
 
 - `scripts/dev/mq_start.sh` — start containers on project-specific ports
 - `scripts/dev/mq_seed.sh` — seed MQ objects
@@ -67,12 +67,12 @@ variables and delegate to the corresponding `mq-dev-environment` scripts:
 - `scripts/dev/mq_stop.sh` — stop containers
 - `scripts/dev/mq_reset.sh` — stop containers and remove volumes
 
-The `mq-dev-environment` repo is expected at `../mq-dev-environment` (sibling
+The `mq-rest-admin-dev-environment` repo is expected at `../mq-rest-admin-dev-environment` (sibling
 directory) by default, overridable via `MQ_DEV_ENV_PATH`.
 
 ## CI
 
-The `mq-dev-environment` composite action (`setup-mq`) accepts `project-name`,
+The `mq-rest-admin-dev-environment` composite action (`setup-mq`) accepts `project-name`,
 `qm1-rest-port`, and `qm2-rest-port` inputs. mq-rest-admin's CI workflow will
 pass its project-specific values.
 

--- a/docs/plans/open-decisions.md
+++ b/docs/plans/open-decisions.md
@@ -69,7 +69,7 @@ implemented. One minor tooling item remains (docs-only validation).
   (decided 2026-02-12).
 - **Integration test strategy**: Each project runs distinct MQ containers via
   COMPOSE_PROJECT_NAME isolation and project-specific port allocation. Shared
-  infrastructure from mq-dev-environment (decided 2026-02-14, see
+  infrastructure from mq-rest-admin-dev-environment (decided 2026-02-14, see
   `docs/plans/2026-02-14-integration-test-strategy.md`).
 
 ## Architecture

--- a/docs/site/docs/development/developer-setup.md
+++ b/docs/site/docs/development/developer-setup.md
@@ -21,7 +21,7 @@ mq-rest-admin depends on two sibling repositories:
 | --- | --- |
 | [mq-rest-admin-java](https://github.com/wphillipmoore/mq-rest-admin-java) | This project |
 | [standards-and-conventions](https://github.com/wphillipmoore/standards-and-conventions) | Canonical project standards (referenced by `AGENTS.md` and git hooks) |
-| [mq-dev-environment](https://github.com/wphillipmoore/mq-dev-environment) | Dockerized MQ test infrastructure (local and CI) |
+| [mq-rest-admin-dev-environment](https://github.com/wphillipmoore/mq-rest-admin-dev-environment) | Dockerized MQ test infrastructure (local and CI) |
 | [mq-rest-admin-common](https://github.com/wphillipmoore/mq-rest-admin-common) | Shared documentation fragments |
 
 ## Recommended directory layout
@@ -33,7 +33,7 @@ Clone all repositories as siblings:
 ├── mq-rest-admin-java/
 ├── mq-rest-admin-common/
 ├── standards-and-conventions/
-└── mq-dev-environment/
+└── mq-rest-admin-dev-environment/
 ```
 
 ```bash
@@ -41,7 +41,7 @@ cd ~/dev/github
 git clone https://github.com/wphillipmoore/mq-rest-admin-java.git
 git clone https://github.com/wphillipmoore/mq-rest-admin-common.git
 git clone https://github.com/wphillipmoore/standards-and-conventions.git
-git clone https://github.com/wphillipmoore/mq-dev-environment.git
+git clone https://github.com/wphillipmoore/mq-rest-admin-dev-environment.git
 ```
 
 ## Initial setup
@@ -171,7 +171,7 @@ validation. The pipeline includes:
 
 - **Unit tests** on Java 17, 21, and 25-ea
 - **Integration tests** against real MQ queue managers via the shared
-  `wphillipmoore/mq-dev-environment/.github/actions/setup-mq` action
+  `wphillipmoore/mq-rest-admin-dev-environment/.github/actions/setup-mq` action
 - **Standards compliance** (Spotless, Checkstyle, SpotBugs, PMD, markdown
   lint, commit messages, repository profile)
 - **Dependency audit** (`dependency-check`)

--- a/scripts/dev/mq_reset.sh
+++ b/scripts/dev/mq_reset.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-dev-environment}"
+mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-rest-admin-dev-environment}"
 
 if [ ! -d "$mq_dev_env" ]; then
-  echo "mq-dev-environment not found at: $mq_dev_env" >&2
+  echo "mq-rest-admin-dev-environment not found at: $mq_dev_env" >&2
   echo "Clone it as a sibling directory or set MQ_DEV_ENV_PATH." >&2
   exit 1
 fi

--- a/scripts/dev/mq_seed.sh
+++ b/scripts/dev/mq_seed.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-dev-environment}"
+mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-rest-admin-dev-environment}"
 
 if [ ! -d "$mq_dev_env" ]; then
-  echo "mq-dev-environment not found at: $mq_dev_env" >&2
+  echo "mq-rest-admin-dev-environment not found at: $mq_dev_env" >&2
   echo "Clone it as a sibling directory or set MQ_DEV_ENV_PATH." >&2
   exit 1
 fi

--- a/scripts/dev/mq_start.sh
+++ b/scripts/dev/mq_start.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-dev-environment}"
+mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-rest-admin-dev-environment}"
 
 if [ ! -d "$mq_dev_env" ]; then
-  echo "mq-dev-environment not found at: $mq_dev_env" >&2
+  echo "mq-rest-admin-dev-environment not found at: $mq_dev_env" >&2
   echo "Clone it as a sibling directory or set MQ_DEV_ENV_PATH." >&2
   exit 1
 fi

--- a/scripts/dev/mq_stop.sh
+++ b/scripts/dev/mq_stop.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-dev-environment}"
+mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-rest-admin-dev-environment}"
 
 if [ ! -d "$mq_dev_env" ]; then
-  echo "mq-dev-environment not found at: $mq_dev_env" >&2
+  echo "mq-rest-admin-dev-environment not found at: $mq_dev_env" >&2
   echo "Clone it as a sibling directory or set MQ_DEV_ENV_PATH." >&2
   exit 1
 fi

--- a/scripts/dev/mq_verify.sh
+++ b/scripts/dev/mq_verify.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-dev-environment}"
+mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-rest-admin-dev-environment}"
 
 if [ ! -d "$mq_dev_env" ]; then
-  echo "mq-dev-environment not found at: $mq_dev_env" >&2
+  echo "mq-rest-admin-dev-environment not found at: $mq_dev_env" >&2
   echo "Clone it as a sibling directory or set MQ_DEV_ENV_PATH." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- Rename all `mq-dev-environment` references to `mq-rest-admin-dev-environment`
- Phase 1, Step 3 of the repository rename plan

## Issue Linkage

- Ref wphillipmoore/mq-dev-environment#14
- Work is not complete until the issue is closed.

## Testing

- markdownlint

Docs-only: tests skipped

Files changed:
- `.github/workflows/ci.yml` (4 references — checkout step name, repository, path, local action path)
- `scripts/dev/mq_start.sh` (2 references — default path, error message)
- `scripts/dev/mq_stop.sh` (2 references)
- `scripts/dev/mq_reset.sh` (2 references)
- `scripts/dev/mq_seed.sh` (2 references)
- `scripts/dev/mq_verify.sh` (2 references)
- `docs/site/docs/development/developer-setup.md` (4 references — table link, directory layout, clone command, CI action reference)
- `docs/plans/2026-02-14-integration-test-strategy.md` (5 references)
- `docs/plans/open-decisions.md` (1 reference)
- `docs/plans/2026-02-14-documentation-architecture.md` (1 reference)

## Notes

- Pre-rename PR per the execution plan. integration-tests CI gate temporarily removed from rulesets to allow merging before the actual rename (Phase 2).