### PR TITLE
chore: add __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@ bin/
 .cursorignore
 .cursorindexingignore
 
+# Python
+__pycache__/
+
 # Documentation
 .mq-rest-admin-common
 docs/site/site/


### PR DESCRIPTION
# Pull Request

## Summary

- Add __pycache__ to .gitignore for shared Python dev tooling

## Issue Linkage

- Fixes #143

## Testing



## Notes

- -
