### PR TITLE
fix(ci): switch Maven Central publish wait to validated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -401,7 +401,7 @@
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>true</autoPublish>
-                            <waitUntil>published</waitUntil>
+                            <waitUntil>validated</waitUntil>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
# Pull Request

## Summary

- Switch central-publishing-maven-plugin waitUntil from published to validated to avoid 30-minute timeout

## Issue Linkage

- Fixes #151

## Testing



## Notes

- -
