### PR TITLE
chore(ci): standardize publish workflow name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to Maven Central
+name: Publish release
 
 on:
   push:


### PR DESCRIPTION
# Pull Request

## Summary

- Standardize publish workflow name to 'Publish release'

## Issue Linkage

- Fixes #169

## Testing



## Notes

- -
