### PR TITLE
ci: assign unique REST API ports per integration test matrix entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
           add-prefix: "src/main/java/"
 
   integration-tests:
-    name: "test: integration"
+    name: "test: integration (${{ matrix.java-version }})"
     runs-on: ubuntu-latest
     needs: docs-only
     strategy:


### PR DESCRIPTION
# Pull Request

## Summary

- Assign unique QM1/QM2 REST API ports (9453-9458) per Java version matrix entry so integration test containers can coexist in parallel

## Issue Linkage

- Fixes #185

## Testing



## Notes

- -