### PR TITLE
fix(queue): add type-specific queue delete methods and remove integration test workarounds

### DIFF
--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/MqRestSession.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/MqRestSession.java
@@ -1167,6 +1167,42 @@ public final class MqRestSession {
     mqscCommand("DELETE", "QUEUE", name, requestParameters, responseParameters, null);
   }
 
+  /** Executes a DELETE QLOCAL MQSC command. */
+  public void deleteQlocal(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    Objects.requireNonNull(name, "name");
+    mqscCommand("DELETE", "QLOCAL", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE QREMOTE MQSC command. */
+  public void deleteQremote(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    Objects.requireNonNull(name, "name");
+    mqscCommand("DELETE", "QREMOTE", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE QALIAS MQSC command. */
+  public void deleteQalias(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    Objects.requireNonNull(name, "name");
+    mqscCommand("DELETE", "QALIAS", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE QMODEL MQSC command. */
+  public void deleteQmodel(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    Objects.requireNonNull(name, "name");
+    mqscCommand("DELETE", "QMODEL", name, requestParameters, responseParameters, null);
+  }
+
   /** Executes a DELETE CHANNEL MQSC command. */
   public void deleteChannel(
       @Nullable String name,

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionCommandsTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionCommandsTest.java
@@ -246,6 +246,34 @@ class MqRestSessionCommandsTest {
     }
 
     @Test
+    void deleteQlocalWithNullNameThrowsNullPointerException() {
+      assertThatThrownBy(() -> session.deleteQlocal(null, null, null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessage("name");
+    }
+
+    @Test
+    void deleteQremoteWithNullNameThrowsNullPointerException() {
+      assertThatThrownBy(() -> session.deleteQremote(null, null, null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessage("name");
+    }
+
+    @Test
+    void deleteQaliasWithNullNameThrowsNullPointerException() {
+      assertThatThrownBy(() -> session.deleteQalias(null, null, null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessage("name");
+    }
+
+    @Test
+    void deleteQmodelWithNullNameThrowsNullPointerException() {
+      assertThatThrownBy(() -> session.deleteQmodel(null, null, null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessage("name");
+    }
+
+    @Test
     void deleteChannelWithNullNameThrowsNullPointerException() {
       assertThatThrownBy(() -> session.deleteChannel(null, null, null))
           .isInstanceOf(NullPointerException.class)
@@ -881,6 +909,30 @@ class MqRestSessionCommandsTest {
     void deleteQueueDispatches() {
       session.deleteQueue("Q1", null, null);
       assertDispatch("DELETE", "QUEUE");
+    }
+
+    @Test
+    void deleteQlocalDispatches() {
+      session.deleteQlocal("Q1", null, null);
+      assertDispatch("DELETE", "QLOCAL");
+    }
+
+    @Test
+    void deleteQremoteDispatches() {
+      session.deleteQremote("Q1", null, null);
+      assertDispatch("DELETE", "QREMOTE");
+    }
+
+    @Test
+    void deleteQaliasDispatches() {
+      session.deleteQalias("Q1", null, null);
+      assertDispatch("DELETE", "QALIAS");
+    }
+
+    @Test
+    void deleteQmodelDispatches() {
+      session.deleteQmodel("Q1", null, null);
+      assertDispatch("DELETE", "QMODEL");
     }
 
     @Test

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionIT.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionIT.java
@@ -245,7 +245,7 @@ class MqRestSessionIT {
                       null),
               () -> session.displayQueue(TEST_QLOCAL, null, null, null),
               () -> {}, // no alter for qlocal in pymqrest reference
-              () -> session.mqscCommand("DELETE", "QLOCAL", TEST_QLOCAL, null, null, null),
+              () -> session.deleteQlocal(TEST_QLOCAL, null, null),
               null),
           new LifecycleCase(
               "qremote",
@@ -262,7 +262,7 @@ class MqRestSessionIT {
                       null),
               () -> session.displayQueue(TEST_QREMOTE, null, null, null),
               () -> {},
-              () -> session.mqscCommand("DELETE", "QREMOTE", TEST_QREMOTE, null, null, null),
+              () -> session.deleteQremote(TEST_QREMOTE, null, null),
               null),
           new LifecycleCase(
               "qalias",
@@ -277,7 +277,7 @@ class MqRestSessionIT {
                       null),
               () -> session.displayQueue(TEST_QALIAS, null, null, null),
               () -> {},
-              () -> session.mqscCommand("DELETE", "QALIAS", TEST_QALIAS, null, null, null),
+              () -> session.deleteQalias(TEST_QALIAS, null, null),
               null),
           new LifecycleCase(
               "qmodel",
@@ -293,7 +293,7 @@ class MqRestSessionIT {
                       null),
               () -> session.displayQueue(TEST_QMODEL, null, null, null),
               () -> {},
-              () -> session.mqscCommand("DELETE", "QMODEL", TEST_QMODEL, null, null, null),
+              () -> session.deleteQmodel(TEST_QMODEL, null, null),
               null),
           new LifecycleCase(
               "channel",
@@ -461,8 +461,7 @@ class MqRestSessionIT {
       MqRestSession nonStrict = buildNonStrictSession();
 
       // Clean up from any prior failed run.
-      silentDelete(
-          () -> nonStrict.mqscCommand("DELETE", "QLOCAL", TEST_ENSURE_QLOCAL, null, null, null));
+      silentDelete(() -> nonStrict.deleteQlocal(TEST_ENSURE_QLOCAL, null, null));
 
       try {
         // Create.
@@ -479,8 +478,7 @@ class MqRestSessionIT {
             nonStrict.ensureQlocal(TEST_ENSURE_QLOCAL, Map.of("description", "ensure updated"));
         assertThat(result.action()).isEqualTo(EnsureAction.UPDATED);
       } finally {
-        silentDelete(
-            () -> nonStrict.mqscCommand("DELETE", "QLOCAL", TEST_ENSURE_QLOCAL, null, null, null));
+        silentDelete(() -> nonStrict.deleteQlocal(TEST_ENSURE_QLOCAL, null, null));
       }
     }
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add type-specific queue delete methods (deleteQlocal, deleteQremote, deleteQalias, deleteQmodel) and replace all raw mqscCommand() workarounds in integration tests with public API methods, achieving parity with Python, Go, and Ruby SDKs

## Issue Linkage

- Fixes #189

## Testing



## Notes

- -