### PR TITLE
fix(docs): correct relative links to mapping-pipeline in api/ensure and api/sync

### DIFF
--- a/docs/site/docs/api/ensure.md
+++ b/docs/site/docs/api/ensure.md
@@ -157,7 +157,7 @@ corrupting `ALTDATE`/`ALTTIME` on every run.
 ## Attribute mapping
 
 The ensure methods participate in the same
-[mapping pipeline](mapping-pipeline.md) as all other command methods.
+[mapping pipeline](../mapping-pipeline.md) as all other command methods.
 Pass `snake_case` attribute names in `requestParameters` and the
 mapping layer translates them to MQSC names for the DISPLAY, DEFINE,
 and ALTER commands automatically.

--- a/docs/site/docs/api/sync.md
+++ b/docs/site/docs/api/sync.md
@@ -174,7 +174,7 @@ treated as stopped for those object types.
 ## Attribute mapping
 
 The sync methods call the internal MQSC command layer, so they participate
-in the same [mapping pipeline](mapping-pipeline.md) as all other
+in the same [mapping pipeline](../mapping-pipeline.md) as all other
 command methods. The status key is checked using both the mapped
 `snake_case` name and the raw MQSC name, so polling works correctly
 regardless of whether mapping is enabled or disabled.


### PR DESCRIPTION
# Pull Request

## Summary

- Fix broken mapping-pipeline relative links in api/ensure.md and api/sync.md that caused docs build failure in strict mode

## Issue Linkage

- Fixes #218

## Testing



## Notes

- -