### PR TITLE
feat: auto-generate all MQSC command methods from mapping-data.json

### DIFF
--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/MqRestSession.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/MqRestSession.java
@@ -683,71 +683,527 @@ public final class MqRestSession {
     return url;
   }
 
-  // ---------------------------------------------------------------------------
-  // Command methods — DISPLAY (wildcard default)
-  // ---------------------------------------------------------------------------
-
-  /** Executes a DISPLAY QUEUE MQSC command. */
-  public List<Map<String, Object>> displayQueue(
+  // BEGIN GENERATED MQSC METHODS
+  /** Executes an ALTER AUTHINFO MQSC command. */
+  public void alterAuthinfo(
       @Nullable String name,
       @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters,
-      @Nullable String where) {
-    return mqscCommand(
-        "DISPLAY",
-        "QUEUE",
-        name != null ? name : "*",
-        requestParameters,
-        responseParameters,
-        where);
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "AUTHINFO", name, requestParameters, responseParameters, null);
   }
 
-  /** Executes a DISPLAY CHANNEL MQSC command. */
-  public List<Map<String, Object>> displayChannel(
+  /** Executes an ALTER BUFFPOOL MQSC command. */
+  public void alterBuffpool(
       @Nullable String name,
       @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters,
-      @Nullable String where) {
-    return mqscCommand(
-        "DISPLAY",
-        "CHANNEL",
-        name != null ? name : "*",
-        requestParameters,
-        responseParameters,
-        where);
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "BUFFPOOL", name, requestParameters, responseParameters, null);
   }
 
-  // ---------------------------------------------------------------------------
-  // Command methods — DISPLAY (singleton return)
-  // ---------------------------------------------------------------------------
+  /** Executes an ALTER CFSTRUCT MQSC command. */
+  public void alterCfstruct(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "CFSTRUCT", name, requestParameters, responseParameters, null);
+  }
 
-  /** Executes a DISPLAY QMGR MQSC command. */
-  public @Nullable Map<String, Object> displayQmgr(
+  /** Executes an ALTER CHANNEL MQSC command. */
+  public void alterChannel(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "CHANNEL", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes an ALTER COMMINFO MQSC command. */
+  public void alterComminfo(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "COMMINFO", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes an ALTER LISTENER MQSC command. */
+  public void alterListener(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "LISTENER", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes an ALTER NAMELIST MQSC command. */
+  public void alterNamelist(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "NAMELIST", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes an ALTER PROCESS MQSC command. */
+  public void alterProcess(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "PROCESS", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes an ALTER PSID MQSC command. */
+  public void alterPsid(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "PSID", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes an ALTER QALIAS MQSC command. */
+  public void alterQalias(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "QALIAS", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes an ALTER QLOCAL MQSC command. */
+  public void alterQlocal(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "QLOCAL", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes an ALTER QMGR MQSC command. */
+  public void alterQmgr(
       @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
-    List<Map<String, Object>> objects =
-        mqscCommand("DISPLAY", "QMGR", null, requestParameters, responseParameters, null);
-    return objects.isEmpty() ? null : objects.get(0);
+    mqscCommand("ALTER", "QMGR", null, requestParameters, responseParameters, null);
   }
 
-  /** Executes a DISPLAY QMSTATUS MQSC command. */
-  public @Nullable Map<String, Object> displayQmstatus(
-      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
-    List<Map<String, Object>> objects =
-        mqscCommand("DISPLAY", "QMSTATUS", null, requestParameters, responseParameters, null);
-    return objects.isEmpty() ? null : objects.get(0);
+  /** Executes an ALTER QMODEL MQSC command. */
+  public void alterQmodel(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "QMODEL", name, requestParameters, responseParameters, null);
   }
 
-  /** Executes a DISPLAY CMDSERV MQSC command. */
-  public @Nullable Map<String, Object> displayCmdserv(
-      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
-    List<Map<String, Object>> objects =
-        mqscCommand("DISPLAY", "CMDSERV", null, requestParameters, responseParameters, null);
-    return objects.isEmpty() ? null : objects.get(0);
+  /** Executes an ALTER QREMOTE MQSC command. */
+  public void alterQremote(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "QREMOTE", name, requestParameters, responseParameters, null);
   }
 
-  // ---------------------------------------------------------------------------
-  // Command methods — DISPLAY (optional name, list return)
-  // ---------------------------------------------------------------------------
+  /** Executes an ALTER SECURITY MQSC command. */
+  public void alterSecurity(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "SECURITY", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes an ALTER SERVICE MQSC command. */
+  public void alterService(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "SERVICE", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes an ALTER SMDS MQSC command. */
+  public void alterSmds(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "SMDS", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes an ALTER STGCLASS MQSC command. */
+  public void alterStgclass(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "STGCLASS", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes an ALTER SUB MQSC command. */
+  public void alterSub(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "SUB", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes an ALTER TOPIC MQSC command. */
+  public void alterTopic(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "TOPIC", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes an ALTER TRACE MQSC command. */
+  public void alterTrace(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ALTER", "TRACE", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes an ARCHIVE LOG MQSC command. */
+  public void archiveLog(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("ARCHIVE", "LOG", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a BACKUP CFSTRUCT MQSC command. */
+  public void backupCfstruct(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("BACKUP", "CFSTRUCT", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a CLEAR QLOCAL MQSC command. */
+  public void clearQlocal(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("CLEAR", "QLOCAL", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a CLEAR TOPICSTR MQSC command. */
+  public void clearTopicstr(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("CLEAR", "TOPICSTR", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE AUTHINFO MQSC command. */
+  public void defineAuthinfo(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DEFINE", "AUTHINFO", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE BUFFPOOL MQSC command. */
+  public void defineBuffpool(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DEFINE", "BUFFPOOL", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE CFSTRUCT MQSC command. */
+  public void defineCfstruct(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DEFINE", "CFSTRUCT", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE CHANNEL MQSC command. */
+  public void defineChannel(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    Objects.requireNonNull(name, "name");
+    mqscCommand("DEFINE", "CHANNEL", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE COMMINFO MQSC command. */
+  public void defineComminfo(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DEFINE", "COMMINFO", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE LISTENER MQSC command. */
+  public void defineListener(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DEFINE", "LISTENER", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE LOG MQSC command. */
+  public void defineLog(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DEFINE", "LOG", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE MAXSMSGS MQSC command. */
+  public void defineMaxsmsgs(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DEFINE", "MAXSMSGS", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE NAMELIST MQSC command. */
+  public void defineNamelist(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DEFINE", "NAMELIST", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE PROCESS MQSC command. */
+  public void defineProcess(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DEFINE", "PROCESS", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE PSID MQSC command. */
+  public void definePsid(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DEFINE", "PSID", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE QALIAS MQSC command. */
+  public void defineQalias(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    Objects.requireNonNull(name, "name");
+    mqscCommand("DEFINE", "QALIAS", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE QLOCAL MQSC command. */
+  public void defineQlocal(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    Objects.requireNonNull(name, "name");
+    mqscCommand("DEFINE", "QLOCAL", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE QMODEL MQSC command. */
+  public void defineQmodel(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    Objects.requireNonNull(name, "name");
+    mqscCommand("DEFINE", "QMODEL", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE QREMOTE MQSC command. */
+  public void defineQremote(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    Objects.requireNonNull(name, "name");
+    mqscCommand("DEFINE", "QREMOTE", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE SERVICE MQSC command. */
+  public void defineService(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DEFINE", "SERVICE", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE STGCLASS MQSC command. */
+  public void defineStgclass(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DEFINE", "STGCLASS", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE SUB MQSC command. */
+  public void defineSub(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DEFINE", "SUB", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DEFINE TOPIC MQSC command. */
+  public void defineTopic(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DEFINE", "TOPIC", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE AUTHINFO MQSC command. */
+  public void deleteAuthinfo(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DELETE", "AUTHINFO", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE AUTHREC MQSC command. */
+  public void deleteAuthrec(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DELETE", "AUTHREC", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE BUFFPOOL MQSC command. */
+  public void deleteBuffpool(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DELETE", "BUFFPOOL", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE CFSTRUCT MQSC command. */
+  public void deleteCfstruct(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DELETE", "CFSTRUCT", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE CHANNEL MQSC command. */
+  public void deleteChannel(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    Objects.requireNonNull(name, "name");
+    mqscCommand("DELETE", "CHANNEL", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE COMMINFO MQSC command. */
+  public void deleteComminfo(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DELETE", "COMMINFO", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE LISTENER MQSC command. */
+  public void deleteListener(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DELETE", "LISTENER", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE NAMELIST MQSC command. */
+  public void deleteNamelist(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DELETE", "NAMELIST", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE POLICY MQSC command. */
+  public void deletePolicy(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DELETE", "POLICY", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE PROCESS MQSC command. */
+  public void deleteProcess(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DELETE", "PROCESS", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE PSID MQSC command. */
+  public void deletePsid(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DELETE", "PSID", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE QALIAS MQSC command. */
+  public void deleteQalias(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    Objects.requireNonNull(name, "name");
+    mqscCommand("DELETE", "QALIAS", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE QLOCAL MQSC command. */
+  public void deleteQlocal(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    Objects.requireNonNull(name, "name");
+    mqscCommand("DELETE", "QLOCAL", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE QMODEL MQSC command. */
+  public void deleteQmodel(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    Objects.requireNonNull(name, "name");
+    mqscCommand("DELETE", "QMODEL", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE QREMOTE MQSC command. */
+  public void deleteQremote(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    Objects.requireNonNull(name, "name");
+    mqscCommand("DELETE", "QREMOTE", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE QUEUE MQSC command. */
+  public void deleteQueue(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    Objects.requireNonNull(name, "name");
+    mqscCommand("DELETE", "QUEUE", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE SERVICE MQSC command. */
+  public void deleteService(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DELETE", "SERVICE", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE STGCLASS MQSC command. */
+  public void deleteStgclass(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DELETE", "STGCLASS", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE SUB MQSC command. */
+  public void deleteSub(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DELETE", "SUB", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a DELETE TOPIC MQSC command. */
+  public void deleteTopic(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("DELETE", "TOPIC", name, requestParameters, responseParameters, null);
+  }
 
   /** Executes a DISPLAY APSTATUS MQSC command. */
   public List<Map<String, Object>> displayApstatus(
@@ -812,6 +1268,21 @@ public final class MqRestSession {
     return mqscCommand("DISPLAY", "CFSTRUCT", name, requestParameters, responseParameters, where);
   }
 
+  /** Executes a DISPLAY CHANNEL MQSC command. */
+  public List<Map<String, Object>> displayChannel(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters,
+      @Nullable String where) {
+    return mqscCommand(
+        "DISPLAY",
+        "CHANNEL",
+        name != null ? name : "*",
+        requestParameters,
+        responseParameters,
+        where);
+  }
+
   /** Executes a DISPLAY CHINIT MQSC command. */
   public List<Map<String, Object>> displayChinit(
       @Nullable String name,
@@ -846,6 +1317,14 @@ public final class MqRestSession {
       @Nullable List<String> responseParameters,
       @Nullable String where) {
     return mqscCommand("DISPLAY", "CLUSQMGR", name, requestParameters, responseParameters, where);
+  }
+
+  /** Executes a DISPLAY CMDSERV MQSC command. */
+  public @Nullable Map<String, Object> displayCmdserv(
+      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
+    List<Map<String, Object>> objects =
+        mqscCommand("DISPLAY", "CMDSERV", null, requestParameters, responseParameters, null);
+    return objects.isEmpty() ? null : objects.get(0);
   }
 
   /** Executes a DISPLAY COMMINFO MQSC command. */
@@ -956,6 +1435,22 @@ public final class MqRestSession {
     return mqscCommand("DISPLAY", "PUBSUB", name, requestParameters, responseParameters, where);
   }
 
+  /** Executes a DISPLAY QMGR MQSC command. */
+  public @Nullable Map<String, Object> displayQmgr(
+      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
+    List<Map<String, Object>> objects =
+        mqscCommand("DISPLAY", "QMGR", null, requestParameters, responseParameters, null);
+    return objects.isEmpty() ? null : objects.get(0);
+  }
+
+  /** Executes a DISPLAY QMSTATUS MQSC command. */
+  public @Nullable Map<String, Object> displayQmstatus(
+      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
+    List<Map<String, Object>> objects =
+        mqscCommand("DISPLAY", "QMSTATUS", null, requestParameters, responseParameters, null);
+    return objects.isEmpty() ? null : objects.get(0);
+  }
+
   /** Executes a DISPLAY QSTATUS MQSC command. */
   public List<Map<String, Object>> displayQstatus(
       @Nullable String name,
@@ -963,6 +1458,21 @@ public final class MqRestSession {
       @Nullable List<String> responseParameters,
       @Nullable String where) {
     return mqscCommand("DISPLAY", "QSTATUS", name, requestParameters, responseParameters, where);
+  }
+
+  /** Executes a DISPLAY QUEUE MQSC command. */
+  public List<Map<String, Object>> displayQueue(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters,
+      @Nullable String where) {
+    return mqscCommand(
+        "DISPLAY",
+        "QUEUE",
+        name != null ? name : "*",
+        requestParameters,
+        responseParameters,
+        where);
   }
 
   /** Executes a DISPLAY SBSTATUS MQSC command. */
@@ -1100,639 +1610,12 @@ public final class MqRestSession {
     return mqscCommand("DISPLAY", "USAGE", name, requestParameters, responseParameters, where);
   }
 
-  // ---------------------------------------------------------------------------
-  // Command methods — DEFINE (required name)
-  // ---------------------------------------------------------------------------
-
-  /** Executes a DEFINE QLOCAL MQSC command. */
-  public void defineQlocal(
+  /** Executes a MOVE QLOCAL MQSC command. */
+  public void moveQlocal(
       @Nullable String name,
       @Nullable Map<String, Object> requestParameters,
       @Nullable List<String> responseParameters) {
-    Objects.requireNonNull(name, "name");
-    mqscCommand("DEFINE", "QLOCAL", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DEFINE QREMOTE MQSC command. */
-  public void defineQremote(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    Objects.requireNonNull(name, "name");
-    mqscCommand("DEFINE", "QREMOTE", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DEFINE QALIAS MQSC command. */
-  public void defineQalias(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    Objects.requireNonNull(name, "name");
-    mqscCommand("DEFINE", "QALIAS", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DEFINE QMODEL MQSC command. */
-  public void defineQmodel(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    Objects.requireNonNull(name, "name");
-    mqscCommand("DEFINE", "QMODEL", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DEFINE CHANNEL MQSC command. */
-  public void defineChannel(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    Objects.requireNonNull(name, "name");
-    mqscCommand("DEFINE", "CHANNEL", name, requestParameters, responseParameters, null);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Command methods — DELETE (required name)
-  // ---------------------------------------------------------------------------
-
-  /** Executes a DELETE QUEUE MQSC command. */
-  public void deleteQueue(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    Objects.requireNonNull(name, "name");
-    mqscCommand("DELETE", "QUEUE", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DELETE QLOCAL MQSC command. */
-  public void deleteQlocal(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    Objects.requireNonNull(name, "name");
-    mqscCommand("DELETE", "QLOCAL", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DELETE QREMOTE MQSC command. */
-  public void deleteQremote(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    Objects.requireNonNull(name, "name");
-    mqscCommand("DELETE", "QREMOTE", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DELETE QALIAS MQSC command. */
-  public void deleteQalias(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    Objects.requireNonNull(name, "name");
-    mqscCommand("DELETE", "QALIAS", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DELETE QMODEL MQSC command. */
-  public void deleteQmodel(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    Objects.requireNonNull(name, "name");
-    mqscCommand("DELETE", "QMODEL", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DELETE CHANNEL MQSC command. */
-  public void deleteChannel(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    Objects.requireNonNull(name, "name");
-    mqscCommand("DELETE", "CHANNEL", name, requestParameters, responseParameters, null);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Command methods — DEFINE (optional name)
-  // ---------------------------------------------------------------------------
-
-  /** Executes a DEFINE AUTHINFO MQSC command. */
-  public void defineAuthinfo(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DEFINE", "AUTHINFO", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DEFINE BUFFPOOL MQSC command. */
-  public void defineBuffpool(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DEFINE", "BUFFPOOL", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DEFINE CFSTRUCT MQSC command. */
-  public void defineCfstruct(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DEFINE", "CFSTRUCT", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DEFINE COMMINFO MQSC command. */
-  public void defineComminfo(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DEFINE", "COMMINFO", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DEFINE LISTENER MQSC command. */
-  public void defineListener(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DEFINE", "LISTENER", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DEFINE LOG MQSC command. */
-  public void defineLog(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DEFINE", "LOG", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DEFINE MAXSMSGS MQSC command. */
-  public void defineMaxsmsgs(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DEFINE", "MAXSMSGS", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DEFINE NAMELIST MQSC command. */
-  public void defineNamelist(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DEFINE", "NAMELIST", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DEFINE PROCESS MQSC command. */
-  public void defineProcess(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DEFINE", "PROCESS", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DEFINE PSID MQSC command. */
-  public void definePsid(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DEFINE", "PSID", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DEFINE SERVICE MQSC command. */
-  public void defineService(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DEFINE", "SERVICE", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DEFINE STGCLASS MQSC command. */
-  public void defineStgclass(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DEFINE", "STGCLASS", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DEFINE SUB MQSC command. */
-  public void defineSub(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DEFINE", "SUB", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DEFINE TOPIC MQSC command. */
-  public void defineTopic(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DEFINE", "TOPIC", name, requestParameters, responseParameters, null);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Command methods — ALTER (no name)
-  // ---------------------------------------------------------------------------
-
-  /** Executes an ALTER QMGR MQSC command. */
-  public void alterQmgr(
-      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
-    mqscCommand("ALTER", "QMGR", null, requestParameters, responseParameters, null);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Command methods — ALTER (optional name)
-  // ---------------------------------------------------------------------------
-
-  /** Executes an ALTER AUTHINFO MQSC command. */
-  public void alterAuthinfo(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("ALTER", "AUTHINFO", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes an ALTER BUFFPOOL MQSC command. */
-  public void alterBuffpool(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("ALTER", "BUFFPOOL", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes an ALTER CFSTRUCT MQSC command. */
-  public void alterCfstruct(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("ALTER", "CFSTRUCT", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes an ALTER CHANNEL MQSC command. */
-  public void alterChannel(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("ALTER", "CHANNEL", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes an ALTER COMMINFO MQSC command. */
-  public void alterComminfo(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("ALTER", "COMMINFO", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes an ALTER LISTENER MQSC command. */
-  public void alterListener(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("ALTER", "LISTENER", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes an ALTER NAMELIST MQSC command. */
-  public void alterNamelist(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("ALTER", "NAMELIST", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes an ALTER PROCESS MQSC command. */
-  public void alterProcess(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("ALTER", "PROCESS", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes an ALTER PSID MQSC command. */
-  public void alterPsid(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("ALTER", "PSID", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes an ALTER SECURITY MQSC command. */
-  public void alterSecurity(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("ALTER", "SECURITY", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes an ALTER SERVICE MQSC command. */
-  public void alterService(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("ALTER", "SERVICE", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes an ALTER SMDS MQSC command. */
-  public void alterSmds(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("ALTER", "SMDS", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes an ALTER STGCLASS MQSC command. */
-  public void alterStgclass(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("ALTER", "STGCLASS", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes an ALTER SUB MQSC command. */
-  public void alterSub(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("ALTER", "SUB", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes an ALTER TOPIC MQSC command. */
-  public void alterTopic(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("ALTER", "TOPIC", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes an ALTER TRACE MQSC command. */
-  public void alterTrace(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("ALTER", "TRACE", name, requestParameters, responseParameters, null);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Command methods — DELETE (optional name)
-  // ---------------------------------------------------------------------------
-
-  /** Executes a DELETE AUTHINFO MQSC command. */
-  public void deleteAuthinfo(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DELETE", "AUTHINFO", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DELETE AUTHREC MQSC command. */
-  public void deleteAuthrec(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DELETE", "AUTHREC", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DELETE BUFFPOOL MQSC command. */
-  public void deleteBuffpool(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DELETE", "BUFFPOOL", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DELETE CFSTRUCT MQSC command. */
-  public void deleteCfstruct(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DELETE", "CFSTRUCT", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DELETE COMMINFO MQSC command. */
-  public void deleteComminfo(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DELETE", "COMMINFO", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DELETE LISTENER MQSC command. */
-  public void deleteListener(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DELETE", "LISTENER", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DELETE NAMELIST MQSC command. */
-  public void deleteNamelist(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DELETE", "NAMELIST", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DELETE POLICY MQSC command. */
-  public void deletePolicy(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DELETE", "POLICY", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DELETE PROCESS MQSC command. */
-  public void deleteProcess(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DELETE", "PROCESS", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DELETE PSID MQSC command. */
-  public void deletePsid(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DELETE", "PSID", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DELETE SERVICE MQSC command. */
-  public void deleteService(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DELETE", "SERVICE", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DELETE STGCLASS MQSC command. */
-  public void deleteStgclass(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DELETE", "STGCLASS", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DELETE SUB MQSC command. */
-  public void deleteSub(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DELETE", "SUB", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a DELETE TOPIC MQSC command. */
-  public void deleteTopic(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("DELETE", "TOPIC", name, requestParameters, responseParameters, null);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Command methods — START (no name)
-  // ---------------------------------------------------------------------------
-
-  /** Executes a START QMGR MQSC command. */
-  public void startQmgr(
-      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
-    mqscCommand("START", "QMGR", null, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a START CMDSERV MQSC command. */
-  public void startCmdserv(
-      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
-    mqscCommand("START", "CMDSERV", null, requestParameters, responseParameters, null);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Command methods — START (optional name)
-  // ---------------------------------------------------------------------------
-
-  /** Executes a START CHANNEL MQSC command. */
-  public void startChannel(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("START", "CHANNEL", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a START CHINIT MQSC command. */
-  public void startChinit(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("START", "CHINIT", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a START LISTENER MQSC command. */
-  public void startListener(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("START", "LISTENER", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a START SERVICE MQSC command. */
-  public void startService(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("START", "SERVICE", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a START SMDSCONN MQSC command. */
-  public void startSmdsconn(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("START", "SMDSCONN", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a START TRACE MQSC command. */
-  public void startTrace(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("START", "TRACE", name, requestParameters, responseParameters, null);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Command methods — STOP (no name)
-  // ---------------------------------------------------------------------------
-
-  /** Executes a STOP QMGR MQSC command. */
-  public void stopQmgr(
-      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
-    mqscCommand("STOP", "QMGR", null, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a STOP CMDSERV MQSC command. */
-  public void stopCmdserv(
-      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
-    mqscCommand("STOP", "CMDSERV", null, requestParameters, responseParameters, null);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Command methods — STOP (optional name)
-  // ---------------------------------------------------------------------------
-
-  /** Executes a STOP CHANNEL MQSC command. */
-  public void stopChannel(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("STOP", "CHANNEL", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a STOP CHINIT MQSC command. */
-  public void stopChinit(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("STOP", "CHINIT", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a STOP CONN MQSC command. */
-  public void stopConn(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("STOP", "CONN", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a STOP LISTENER MQSC command. */
-  public void stopListener(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("STOP", "LISTENER", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a STOP SERVICE MQSC command. */
-  public void stopService(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("STOP", "SERVICE", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a STOP SMDSCONN MQSC command. */
-  public void stopSmdsconn(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("STOP", "SMDSCONN", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a STOP TRACE MQSC command. */
-  public void stopTrace(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("STOP", "TRACE", name, requestParameters, responseParameters, null);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Command methods — PING
-  // ---------------------------------------------------------------------------
-
-  /** Executes a PING QMGR MQSC command. */
-  public void pingQmgr(
-      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
-    mqscCommand("PING", "QMGR", null, requestParameters, responseParameters, null);
+    mqscCommand("MOVE", "QLOCAL", name, requestParameters, responseParameters, null);
   }
 
   /** Executes a PING CHANNEL MQSC command. */
@@ -1743,34 +1626,34 @@ public final class MqRestSession {
     mqscCommand("PING", "CHANNEL", name, requestParameters, responseParameters, null);
   }
 
-  // ---------------------------------------------------------------------------
-  // Command methods — CLEAR (optional name)
-  // ---------------------------------------------------------------------------
-
-  /** Executes a CLEAR QLOCAL MQSC command. */
-  public void clearQlocal(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("CLEAR", "QLOCAL", name, requestParameters, responseParameters, null);
-  }
-
-  /** Executes a CLEAR TOPICSTR MQSC command. */
-  public void clearTopicstr(
-      @Nullable String name,
-      @Nullable Map<String, Object> requestParameters,
-      @Nullable List<String> responseParameters) {
-    mqscCommand("CLEAR", "TOPICSTR", name, requestParameters, responseParameters, null);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Command methods — REFRESH
-  // ---------------------------------------------------------------------------
-
-  /** Executes a REFRESH QMGR MQSC command. */
-  public void refreshQmgr(
+  /** Executes a PING QMGR MQSC command. */
+  public void pingQmgr(
       @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
-    mqscCommand("REFRESH", "QMGR", null, requestParameters, responseParameters, null);
+    mqscCommand("PING", "QMGR", null, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a PURGE CHANNEL MQSC command. */
+  public void purgeChannel(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("PURGE", "CHANNEL", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a RECOVER BSDS MQSC command. */
+  public void recoverBsds(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("RECOVER", "BSDS", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a RECOVER CFSTRUCT MQSC command. */
+  public void recoverCfstruct(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("RECOVER", "CFSTRUCT", name, requestParameters, responseParameters, null);
   }
 
   /** Executes a REFRESH CLUSTER MQSC command. */
@@ -1781,22 +1664,18 @@ public final class MqRestSession {
     mqscCommand("REFRESH", "CLUSTER", name, requestParameters, responseParameters, null);
   }
 
+  /** Executes a REFRESH QMGR MQSC command. */
+  public void refreshQmgr(
+      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
+    mqscCommand("REFRESH", "QMGR", null, requestParameters, responseParameters, null);
+  }
+
   /** Executes a REFRESH SECURITY MQSC command. */
   public void refreshSecurity(
       @Nullable String name,
       @Nullable Map<String, Object> requestParameters,
       @Nullable List<String> responseParameters) {
     mqscCommand("REFRESH", "SECURITY", name, requestParameters, responseParameters, null);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Command methods — RESET
-  // ---------------------------------------------------------------------------
-
-  /** Executes a RESET QMGR MQSC command. */
-  public void resetQmgr(
-      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
-    mqscCommand("RESET", "QMGR", null, requestParameters, responseParameters, null);
   }
 
   /** Executes a RESET CFSTRUCT MQSC command. */
@@ -1823,6 +1702,12 @@ public final class MqRestSession {
     mqscCommand("RESET", "CLUSTER", name, requestParameters, responseParameters, null);
   }
 
+  /** Executes a RESET QMGR MQSC command. */
+  public void resetQmgr(
+      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
+    mqscCommand("RESET", "QMGR", null, requestParameters, responseParameters, null);
+  }
+
   /** Executes a RESET QSTATS MQSC command. */
   public void resetQstats(
       @Nullable String name,
@@ -1847,10 +1732,6 @@ public final class MqRestSession {
     mqscCommand("RESET", "TPIPE", name, requestParameters, responseParameters, null);
   }
 
-  // ---------------------------------------------------------------------------
-  // Command methods — RESOLVE (optional name)
-  // ---------------------------------------------------------------------------
-
   /** Executes a RESOLVE CHANNEL MQSC command. */
   public void resolveChannel(
       @Nullable String name,
@@ -1867,25 +1748,19 @@ public final class MqRestSession {
     mqscCommand("RESOLVE", "INDOUBT", name, requestParameters, responseParameters, null);
   }
 
-  // ---------------------------------------------------------------------------
-  // Command methods — RESUME / SUSPEND (no name)
-  // ---------------------------------------------------------------------------
-
   /** Executes a RESUME QMGR MQSC command. */
   public void resumeQmgr(
       @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
     mqscCommand("RESUME", "QMGR", null, requestParameters, responseParameters, null);
   }
 
-  /** Executes a SUSPEND QMGR MQSC command. */
-  public void suspendQmgr(
-      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
-    mqscCommand("SUSPEND", "QMGR", null, requestParameters, responseParameters, null);
+  /** Executes a RVERIFY SECURITY MQSC command. */
+  public void rverifySecurity(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("RVERIFY", "SECURITY", name, requestParameters, responseParameters, null);
   }
-
-  // ---------------------------------------------------------------------------
-  // Command methods — SET (optional name)
-  // ---------------------------------------------------------------------------
 
   /** Executes a SET ARCHIVE MQSC command. */
   public void setArchive(
@@ -1935,65 +1810,141 @@ public final class MqRestSession {
     mqscCommand("SET", "SYSTEM", name, requestParameters, responseParameters, null);
   }
 
-  // ---------------------------------------------------------------------------
-  // Command methods — Miscellaneous (optional name)
-  // ---------------------------------------------------------------------------
-
-  /** Executes an ARCHIVE LOG MQSC command. */
-  public void archiveLog(
+  /** Executes a START CHANNEL MQSC command. */
+  public void startChannel(
       @Nullable String name,
       @Nullable Map<String, Object> requestParameters,
       @Nullable List<String> responseParameters) {
-    mqscCommand("ARCHIVE", "LOG", name, requestParameters, responseParameters, null);
+    mqscCommand("START", "CHANNEL", name, requestParameters, responseParameters, null);
   }
 
-  /** Executes a BACKUP CFSTRUCT MQSC command. */
-  public void backupCfstruct(
+  /** Executes a START CHINIT MQSC command. */
+  public void startChinit(
       @Nullable String name,
       @Nullable Map<String, Object> requestParameters,
       @Nullable List<String> responseParameters) {
-    mqscCommand("BACKUP", "CFSTRUCT", name, requestParameters, responseParameters, null);
+    mqscCommand("START", "CHINIT", name, requestParameters, responseParameters, null);
   }
 
-  /** Executes a RECOVER BSDS MQSC command. */
-  public void recoverBsds(
+  /** Executes a START CMDSERV MQSC command. */
+  public void startCmdserv(
+      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
+    mqscCommand("START", "CMDSERV", null, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a START LISTENER MQSC command. */
+  public void startListener(
       @Nullable String name,
       @Nullable Map<String, Object> requestParameters,
       @Nullable List<String> responseParameters) {
-    mqscCommand("RECOVER", "BSDS", name, requestParameters, responseParameters, null);
+    mqscCommand("START", "LISTENER", name, requestParameters, responseParameters, null);
   }
 
-  /** Executes a RECOVER CFSTRUCT MQSC command. */
-  public void recoverCfstruct(
+  /** Executes a START QMGR MQSC command. */
+  public void startQmgr(
+      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
+    mqscCommand("START", "QMGR", null, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a START SERVICE MQSC command. */
+  public void startService(
       @Nullable String name,
       @Nullable Map<String, Object> requestParameters,
       @Nullable List<String> responseParameters) {
-    mqscCommand("RECOVER", "CFSTRUCT", name, requestParameters, responseParameters, null);
+    mqscCommand("START", "SERVICE", name, requestParameters, responseParameters, null);
   }
 
-  /** Executes a PURGE CHANNEL MQSC command. */
-  public void purgeChannel(
+  /** Executes a START SMDSCONN MQSC command. */
+  public void startSmdsconn(
       @Nullable String name,
       @Nullable Map<String, Object> requestParameters,
       @Nullable List<String> responseParameters) {
-    mqscCommand("PURGE", "CHANNEL", name, requestParameters, responseParameters, null);
+    mqscCommand("START", "SMDSCONN", name, requestParameters, responseParameters, null);
   }
 
-  /** Executes a MOVE QLOCAL MQSC command. */
-  public void moveQlocal(
+  /** Executes a START TRACE MQSC command. */
+  public void startTrace(
       @Nullable String name,
       @Nullable Map<String, Object> requestParameters,
       @Nullable List<String> responseParameters) {
-    mqscCommand("MOVE", "QLOCAL", name, requestParameters, responseParameters, null);
+    mqscCommand("START", "TRACE", name, requestParameters, responseParameters, null);
   }
 
-  /** Executes a RVERIFY SECURITY MQSC command. */
-  public void rverifySecurity(
+  /** Executes a STOP CHANNEL MQSC command. */
+  public void stopChannel(
       @Nullable String name,
       @Nullable Map<String, Object> requestParameters,
       @Nullable List<String> responseParameters) {
-    mqscCommand("RVERIFY", "SECURITY", name, requestParameters, responseParameters, null);
+    mqscCommand("STOP", "CHANNEL", name, requestParameters, responseParameters, null);
   }
+
+  /** Executes a STOP CHINIT MQSC command. */
+  public void stopChinit(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("STOP", "CHINIT", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a STOP CMDSERV MQSC command. */
+  public void stopCmdserv(
+      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
+    mqscCommand("STOP", "CMDSERV", null, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a STOP CONN MQSC command. */
+  public void stopConn(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("STOP", "CONN", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a STOP LISTENER MQSC command. */
+  public void stopListener(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("STOP", "LISTENER", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a STOP QMGR MQSC command. */
+  public void stopQmgr(
+      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
+    mqscCommand("STOP", "QMGR", null, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a STOP SERVICE MQSC command. */
+  public void stopService(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("STOP", "SERVICE", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a STOP SMDSCONN MQSC command. */
+  public void stopSmdsconn(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("STOP", "SMDSCONN", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a STOP TRACE MQSC command. */
+  public void stopTrace(
+      @Nullable String name,
+      @Nullable Map<String, Object> requestParameters,
+      @Nullable List<String> responseParameters) {
+    mqscCommand("STOP", "TRACE", name, requestParameters, responseParameters, null);
+  }
+
+  /** Executes a SUSPEND QMGR MQSC command. */
+  public void suspendQmgr(
+      @Nullable Map<String, Object> requestParameters, @Nullable List<String> responseParameters) {
+    mqscCommand("SUSPEND", "QMGR", null, requestParameters, responseParameters, null);
+  }
+
+  // END GENERATED MQSC METHODS
 
   // ---------------------------------------------------------------------------
   // Ensure methods — idempotent upsert operations

--- a/src/main/resources/io/github/wphillipmoore/mq/rest/admin/mapping/mapping-data.json
+++ b/src/main/resources/io/github/wphillipmoore/mq/rest/admin/mapping/mapping-data.json
@@ -27,8 +27,20 @@
     "ALTER PSID": {
       "qualifier": "psid"
     },
+    "ALTER QALIAS": {
+      "qualifier": "queue"
+    },
+    "ALTER QLOCAL": {
+      "qualifier": "queue"
+    },
     "ALTER QMGR": {
       "qualifier": "qmgr"
+    },
+    "ALTER QMODEL": {
+      "qualifier": "queue"
+    },
+    "ALTER QREMOTE": {
+      "qualifier": "queue"
     },
     "ALTER SECURITY": {
       "qualifier": "security"
@@ -73,7 +85,8 @@
       "qualifier": "cfstruct"
     },
     "DEFINE CHANNEL": {
-      "qualifier": "channel"
+      "qualifier": "channel",
+      "name_required": true
     },
     "DEFINE COMMINFO": {
       "qualifier": "comminfo"
@@ -95,6 +108,22 @@
     },
     "DEFINE PSID": {
       "qualifier": "psid"
+    },
+    "DEFINE QALIAS": {
+      "qualifier": "queue",
+      "name_required": true
+    },
+    "DEFINE QLOCAL": {
+      "qualifier": "queue",
+      "name_required": true
+    },
+    "DEFINE QMODEL": {
+      "qualifier": "queue",
+      "name_required": true
+    },
+    "DEFINE QREMOTE": {
+      "qualifier": "queue",
+      "name_required": true
     },
     "DEFINE SERVICE": {
       "qualifier": "service"
@@ -121,7 +150,8 @@
       "qualifier": "cfstruct"
     },
     "DELETE CHANNEL": {
-      "qualifier": "channel"
+      "qualifier": "channel",
+      "name_required": true
     },
     "DELETE COMMINFO": {
       "qualifier": "comminfo"
@@ -141,6 +171,26 @@
     "DELETE PSID": {
       "qualifier": "psid"
     },
+    "DELETE QALIAS": {
+      "qualifier": "queue",
+      "name_required": true
+    },
+    "DELETE QLOCAL": {
+      "qualifier": "queue",
+      "name_required": true
+    },
+    "DELETE QMODEL": {
+      "qualifier": "queue",
+      "name_required": true
+    },
+    "DELETE QREMOTE": {
+      "qualifier": "queue",
+      "name_required": true
+    },
+    "DELETE QUEUE": {
+      "qualifier": "queue",
+      "name_required": true
+    },
     "DELETE SERVICE": {
       "qualifier": "service"
     },
@@ -149,18 +199,6 @@
     },
     "DELETE SUB": {
       "qualifier": "sub"
-    },
-    "DELETE QALIAS": {
-      "qualifier": "queue"
-    },
-    "DELETE QLOCAL": {
-      "qualifier": "queue"
-    },
-    "DELETE QMODEL": {
-      "qualifier": "queue"
-    },
-    "DELETE QREMOTE": {
-      "qualifier": "queue"
     },
     "DELETE TOPIC": {
       "qualifier": "topic"
@@ -192,7 +230,9 @@
       "qualifier": "cfstruct"
     },
     "DISPLAY CHANNEL": {
-      "qualifier": "channel"
+      "qualifier": "channel",
+      "pattern": "list",
+      "name_default": "*"
     },
     "DISPLAY CHINIT": {
       "qualifier": "chinit"
@@ -207,7 +247,8 @@
       "qualifier": "clusqmgr"
     },
     "DISPLAY CMDSERV": {
-      "qualifier": "cmdserv"
+      "qualifier": "cmdserv",
+      "pattern": "singleton"
     },
     "DISPLAY COMMINFO": {
       "qualifier": "comminfo"
@@ -259,13 +300,15 @@
         "EVENT",
         "PUBSUB",
         "SYSTEM"
-      ]
+      ],
+      "pattern": "singleton"
     },
     "DISPLAY QMSTATUS": {
       "qualifier": "qmstatus",
       "response_parameter_macros": [
         "LOG"
-      ]
+      ],
+      "pattern": "singleton"
     },
     "DISPLAY QSTATUS": {
       "qualifier": "qstatus",
@@ -277,7 +320,9 @@
       "qualifier": "queue",
       "response_parameter_macros": [
         "CLUSINFO"
-      ]
+      ],
+      "pattern": "list",
+      "name_default": "*"
     },
     "DISPLAY SBSTATUS": {
       "qualifier": "sbstatus"
@@ -303,11 +348,11 @@
         "SUMMARY"
       ]
     },
-    "DISPLAY SYSTEM": {
-      "qualifier": "system"
-    },
     "DISPLAY SVSTATUS": {
       "qualifier": "svstatus"
+    },
+    "DISPLAY SYSTEM": {
+      "qualifier": "system"
     },
     "DISPLAY TCLUSTER": {
       "qualifier": "tcluster"

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionCommandsTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionCommandsTest.java
@@ -860,6 +860,30 @@ class MqRestSessionCommandsTest {
     }
 
     @Test
+    void alterQaliasDispatches() {
+      session.alterQalias(null, null, null);
+      assertDispatch("ALTER", "QALIAS");
+    }
+
+    @Test
+    void alterQlocalDispatches() {
+      session.alterQlocal(null, null, null);
+      assertDispatch("ALTER", "QLOCAL");
+    }
+
+    @Test
+    void alterQmodelDispatches() {
+      session.alterQmodel(null, null, null);
+      assertDispatch("ALTER", "QMODEL");
+    }
+
+    @Test
+    void alterQremoteDispatches() {
+      session.alterQremote(null, null, null);
+      assertDispatch("ALTER", "QREMOTE");
+    }
+
+    @Test
     void alterSecurityDispatches() {
       session.alterSecurity(null, null, null);
       assertDispatch("ALTER", "SECURITY");


### PR DESCRIPTION
# Pull Request

## Summary

- Auto-generate all 152 MQSC command methods from mapping-data.json

## Issue Linkage

- Fixes #229

## Testing



## Notes

- -