### PR TITLE
fix: LTPA cookie extraction uses prefix matching for suffixed cookie names

### DIFF
--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/MqRestSession.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/MqRestSession.java
@@ -360,7 +360,7 @@ public final class MqRestSession {
     }
 
     String[] result = extractLtpaToken(response.headers());
-    if (result == null) {
+    if (result.length == 0) {
       throw new MqRestAuthException(
           "LTPA login succeeded but LtpaToken2 cookie not found in response",
           loginUrl,
@@ -370,7 +370,7 @@ public final class MqRestSession {
     this.ltpaToken = result[1];
   }
 
-  static String @Nullable [] extractLtpaToken(Map<String, String> headers) {
+  static String[] extractLtpaToken(Map<String, String> headers) {
     // Look for Set-Cookie header (case-insensitive)
     String setCookie = null;
     for (Map.Entry<String, String> entry : headers.entrySet()) {
@@ -380,7 +380,7 @@ public final class MqRestSession {
       }
     }
     if (setCookie == null) {
-      return null;
+      return new String[0];
     }
     // Parse cookie string for LtpaToken2 (exact or prefixed name)
     for (String part : setCookie.split(";")) {
@@ -394,7 +394,7 @@ public final class MqRestSession {
         }
       }
     }
-    return null;
+    return new String[0];
   }
 
   String resolveMappingQualifier(String command, String qualifier) {

--- a/src/main/java/io/github/wphillipmoore/mq/rest/admin/MqRestSession.java
+++ b/src/main/java/io/github/wphillipmoore/mq/rest/admin/MqRestSession.java
@@ -88,6 +88,7 @@ public final class MqRestSession {
   private final AttributeMapper attributeMapper;
 
   private Clock clock = new SystemClock();
+  private @Nullable String ltpaCookieName;
   private @Nullable String ltpaToken;
   private @Nullable Integer lastHttpStatus;
   private @Nullable String lastResponseText;
@@ -321,7 +322,7 @@ public final class MqRestSession {
       headers.put(
           "Authorization", buildBasicAuthHeader(basicAuth.username(), basicAuth.password()));
     } else if (ltpaToken != null) {
-      headers.put("Cookie", LTPA_COOKIE_NAME + "=" + ltpaToken);
+      headers.put("Cookie", ltpaCookieName + "=" + ltpaToken);
     }
     // CertificateAuth: no auth header needed (mTLS handled by transport)
     if (csrfToken != null) {
@@ -358,17 +359,18 @@ public final class MqRestSession {
       throw new MqRestAuthException("LTPA login failed", loginUrl, response.statusCode());
     }
 
-    String token = extractLtpaToken(response.headers());
-    if (token == null) {
+    String[] result = extractLtpaToken(response.headers());
+    if (result == null) {
       throw new MqRestAuthException(
           "LTPA login succeeded but LtpaToken2 cookie not found in response",
           loginUrl,
           response.statusCode());
     }
-    this.ltpaToken = token;
+    this.ltpaCookieName = result[0];
+    this.ltpaToken = result[1];
   }
 
-  static @Nullable String extractLtpaToken(Map<String, String> headers) {
+  static String @Nullable [] extractLtpaToken(Map<String, String> headers) {
     // Look for Set-Cookie header (case-insensitive)
     String setCookie = null;
     for (Map.Entry<String, String> entry : headers.entrySet()) {
@@ -380,11 +382,16 @@ public final class MqRestSession {
     if (setCookie == null) {
       return null;
     }
-    // Parse cookie string for LtpaToken2
+    // Parse cookie string for LtpaToken2 (exact or prefixed name)
     for (String part : setCookie.split(";")) {
       String trimmed = part.trim();
-      if (trimmed.startsWith(LTPA_COOKIE_NAME + "=")) {
-        return trimmed.substring(LTPA_COOKIE_NAME.length() + 1);
+      if (trimmed.startsWith(LTPA_COOKIE_NAME)) {
+        int eqIndex = trimmed.indexOf('=');
+        if (eqIndex > 0) {
+          String cookieName = trimmed.substring(0, eqIndex);
+          String cookieValue = trimmed.substring(eqIndex + 1);
+          return new String[] {cookieName, cookieValue};
+        }
       }
     }
     return null;

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionIT.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionIT.java
@@ -7,7 +7,6 @@ import io.github.wphillipmoore.mq.rest.admin.auth.LtpaAuth;
 import io.github.wphillipmoore.mq.rest.admin.ensure.EnsureAction;
 import io.github.wphillipmoore.mq.rest.admin.ensure.EnsureResult;
 import io.github.wphillipmoore.mq.rest.admin.exception.MqRestCommandException;
-import io.github.wphillipmoore.mq.rest.admin.exception.MqRestException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -25,7 +24,6 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -648,7 +646,7 @@ class MqRestSessionIT {
   }
 
   // -------------------------------------------------------------------------
-  // LTPA auth tests — expected to fail on MQ developer containers
+  // LTPA auth tests
   // -------------------------------------------------------------------------
 
   @Nested
@@ -656,29 +654,17 @@ class MqRestSessionIT {
 
     @Test
     void ltpaAuthDisplayQmgr() {
-      MqRestSession ltpaSession;
-      try {
-        ltpaSession =
-            new MqRestSession.Builder(
-                    REST_BASE_URL, QM1_NAME, new LtpaAuth(ADMIN_USER, ADMIN_PASSWORD))
-                .transport(new HttpClientTransport())
-                .verifyTls(false)
-                .build();
-      } catch (MqRestException e) {
-        Assumptions.abort(
-            "LTPA session creation failed (expected on dev containers): " + e.getMessage());
-        return;
-      }
+      MqRestSession ltpaSession =
+          new MqRestSession.Builder(
+                  REST_BASE_URL, QM1_NAME, new LtpaAuth(ADMIN_USER, ADMIN_PASSWORD))
+              .transport(new HttpClientTransport())
+              .verifyTls(false)
+              .build();
 
-      try {
-        Map<String, Object> result = ltpaSession.displayQmgr(null, null);
+      Map<String, Object> result = ltpaSession.displayQmgr(null, null);
 
-        assertThat(result).isNotNull();
-        assertThat(containsStringValue(result, QM1_NAME)).isTrue();
-      } catch (MqRestException e) {
-        Assumptions.abort(
-            "LTPA DisplayQmgr failed (expected on dev containers): " + e.getMessage());
-      }
+      assertThat(result).isNotNull();
+      assertThat(containsStringValue(result, QM1_NAME)).isTrue();
     }
   }
 

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionTest.java
@@ -1146,8 +1146,7 @@ class MqRestSessionTest {
 
     @Test
     void extractLtpaTokenReturnsNullWhenNameHasNoEquals() {
-      String[] result =
-          MqRestSession.extractLtpaToken(Map.of("Set-Cookie", "LtpaToken2; Path=/"));
+      String[] result = MqRestSession.extractLtpaToken(Map.of("Set-Cookie", "LtpaToken2; Path=/"));
 
       assertThat(result).isNull();
     }

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionTest.java
@@ -1145,6 +1145,14 @@ class MqRestSessionTest {
     }
 
     @Test
+    void extractLtpaTokenReturnsNullWhenNameHasNoEquals() {
+      String[] result =
+          MqRestSession.extractLtpaToken(Map.of("Set-Cookie", "LtpaToken2; Path=/"));
+
+      assertThat(result).isNull();
+    }
+
+    @Test
     void extractLtpaTokenReturnsNullWhenWrongCookieName() {
       String[] result =
           MqRestSession.extractLtpaToken(Map.of("Set-Cookie", "JSESSIONID=abc123; Path=/"));

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionTest.java
@@ -1109,33 +1109,47 @@ class MqRestSessionTest {
 
     @Test
     void extractLtpaTokenFromSetCookie() {
-      String token =
+      String[] result =
           MqRestSession.extractLtpaToken(Map.of("Set-Cookie", "LtpaToken2=mytoken; Path=/"));
 
-      assertThat(token).isEqualTo("mytoken");
+      assertThat(result).isNotNull();
+      assertThat(result[0]).isEqualTo("LtpaToken2");
+      assertThat(result[1]).isEqualTo("mytoken");
+    }
+
+    @Test
+    void extractLtpaTokenWithSuffixedCookieName() {
+      String[] result =
+          MqRestSession.extractLtpaToken(
+              Map.of("Set-Cookie", "LtpaToken2_abcdef=suffixed_tok; Path=/"));
+
+      assertThat(result).isNotNull();
+      assertThat(result[0]).isEqualTo("LtpaToken2_abcdef");
+      assertThat(result[1]).isEqualTo("suffixed_tok");
     }
 
     @Test
     void extractLtpaTokenCaseInsensitiveHeader() {
-      String token =
+      String[] result =
           MqRestSession.extractLtpaToken(Map.of("set-cookie", "LtpaToken2=mytoken; Path=/"));
 
-      assertThat(token).isEqualTo("mytoken");
+      assertThat(result).isNotNull();
+      assertThat(result[1]).isEqualTo("mytoken");
     }
 
     @Test
     void extractLtpaTokenReturnsNullWhenNoSetCookie() {
-      String token = MqRestSession.extractLtpaToken(Map.of("Content-Type", "text/html"));
+      String[] result = MqRestSession.extractLtpaToken(Map.of("Content-Type", "text/html"));
 
-      assertThat(token).isNull();
+      assertThat(result).isNull();
     }
 
     @Test
     void extractLtpaTokenReturnsNullWhenWrongCookieName() {
-      String token =
+      String[] result =
           MqRestSession.extractLtpaToken(Map.of("Set-Cookie", "JSESSIONID=abc123; Path=/"));
 
-      assertThat(token).isNull();
+      assertThat(result).isNull();
     }
 
     @Test

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionTest.java
@@ -1141,14 +1141,14 @@ class MqRestSessionTest {
     void extractLtpaTokenReturnsNullWhenNoSetCookie() {
       String[] result = MqRestSession.extractLtpaToken(Map.of("Content-Type", "text/html"));
 
-      assertThat(result).isNull();
+      assertThat(result).isEmpty();
     }
 
     @Test
     void extractLtpaTokenReturnsNullWhenNameHasNoEquals() {
       String[] result = MqRestSession.extractLtpaToken(Map.of("Set-Cookie", "LtpaToken2; Path=/"));
 
-      assertThat(result).isNull();
+      assertThat(result).isEmpty();
     }
 
     @Test
@@ -1156,7 +1156,7 @@ class MqRestSessionTest {
       String[] result =
           MqRestSession.extractLtpaToken(Map.of("Set-Cookie", "JSESSIONID=abc123; Path=/"));
 
-      assertThat(result).isNull();
+      assertThat(result).isEmpty();
     }
 
     @Test
@@ -1177,14 +1177,14 @@ class MqRestSessionTest {
     void extractOptionalIntFromNullReturnsNull() {
       Integer result = MqRestSession.extractOptionalInt(null);
 
-      assertThat(result).isNull();
+      assertThat(result).isEmpty();
     }
 
     @Test
     void extractOptionalIntFromStringReturnsNull() {
       Integer result = MqRestSession.extractOptionalInt("not a number");
 
-      assertThat(result).isNull();
+      assertThat(result).isEmpty();
     }
 
     @Test

--- a/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionTest.java
+++ b/src/test/java/io/github/wphillipmoore/mq/rest/admin/MqRestSessionTest.java
@@ -1177,14 +1177,14 @@ class MqRestSessionTest {
     void extractOptionalIntFromNullReturnsNull() {
       Integer result = MqRestSession.extractOptionalInt(null);
 
-      assertThat(result).isEmpty();
+      assertThat(result).isNull();
     }
 
     @Test
     void extractOptionalIntFromStringReturnsNull() {
       Integer result = MqRestSession.extractOptionalInt("not a number");
 
-      assertThat(result).isEmpty();
+      assertThat(result).isNull();
     }
 
     @Test


### PR DESCRIPTION
# Pull Request

## Summary

- Use prefix matching for LTPA cookie extraction to support Liberty suffixed cookie names

## Issue Linkage

- Fixes #232

## Testing



## Notes

- -