### PR TITLE
chore: add .markdownlintignore for auto-generated files

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,2 @@
+CHANGELOG.md
+releases/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,12 @@ This repository follows the canonical standards and conventions in the
 `standards-and-conventions` repository.
 
 Resolve the local path (preferred):
+
 - `../standards-and-conventions`
 
 If the local path is unavailable, use the canonical web source:
-- https://github.com/wphillipmoore/standards-and-conventions
+
+- <https://github.com/wphillipmoore/standards-and-conventions>
 
 If the canonical standards cannot be retrieved, treat it as a fatal
 exception and stop.
@@ -26,6 +28,7 @@ exception and stop.
 ## Shared Skills
 
 Replace `<standards-repo-path>` with the resolved local path when available.
+
 - Load all skills from: `<standards-repo-path>/skills/**/SKILL.md`
 - Treat every skill found under that directory as available and active.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Java wrapper for the IBM MQ administrative REST API, ported from `pymqrest` (Pyt
 
 **Java package**: `io.github.wphillipmoore.mq.rest.admin`
 
-**Canonical Standards**: https://github.com/wphillipmoore/standards-and-conventions (local: `../standards-and-conventions`)
+**Canonical Standards**: <https://github.com/wphillipmoore/standards-and-conventions> (local: `../standards-and-conventions`)
 
 **Reference implementation**: `../mq-rest-admin-python`
 
@@ -147,6 +147,7 @@ export MQ_REST_ADMIN_RUN_INTEGRATION=true
 ```
 
 Container details:
+
 - Queue managers: `QM1` and `QM2`
 - QM1 ports: `1424` (MQ listener), `9453` (REST API)
 - QM2 ports: `1425` (MQ listener), `9454` (REST API)
@@ -171,7 +172,7 @@ Direct port of pymqrest's architecture, adapted to Java idioms.
 
 ### Exception Hierarchy
 
-```
+```text
 MqRestException (sealed, RuntimeException)
 ├── MqRestTransportException   (network/connection)
 ├── MqRestResponseException    (malformed JSON)
@@ -184,7 +185,7 @@ MappingException (separate, data-transformation errors)
 
 ### Package Layout
 
-```
+```text
 .admin          — MqRestSession (Builder pattern), MqRestTransport, HttpClientTransport, TransportResponse
 .admin.auth     — Credentials (sealed), BasicAuth, LtpaAuth, CertificateAuth
 .admin.exception — Sealed exception hierarchy

--- a/standards-and-conventions.md
+++ b/standards-and-conventions.md
@@ -1,6 +1,7 @@
 # Standards Bootstrap
 
 ## Table of Contents
+
 - [Includes](#includes)
 
 ## Includes


### PR DESCRIPTION
# Pull Request

## Summary

- Add .markdownlintignore to exclude CHANGELOG.md and releases/ from markdownlint scope

## Issue Linkage

- Ref wphillipmoore/mq-rest-admin-common#190

## Testing

- markdownlint

## Notes

- Part of cross-repo rollout across all managed repositories