### PR TITLE
refactor: migrate publish workflow to shared reusable workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,119 +11,59 @@ permissions:
   id-token: write
   pull-requests: write
 
-concurrency:
-  group: publish
-  cancel-in-progress: false
-
 jobs:
   publish:
-    name: "publish: release"
-    runs-on: ubuntu-latest
-    env:
-      HAS_MAVEN_CREDENTIALS: ${{ secrets.CENTRAL_TOKEN != '' }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@develop
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+      pull-requests: write
+    with:
+      ecosystem: java
+      version-command: >-
+        ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout
+      registry-check-command: >-
+        status_code=$(curl -s -o /dev/null -w "%{http_code}"
+        "https://repo1.maven.org/maven2/io/github/wphillipmoore/mq-rest-admin/$VERSION/");
+        if [ "$status_code" = "200" ]; then echo "exists"; else echo "not_found"; fi
+      build-command: ./mvnw verify -B
+      attestation-subject-path: "target/*.jar"
+      sbom-output-file: "dist/mq-rest-admin-$VERSION.cdx.json"
+      registry-publish-command: ./mvnw deploy -B -Prelease -DskipTests
+      release-title: mq-rest-admin
+      release-notes: |
+        ## Installation
 
-      - name: Set up Java 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: "17"
-          cache: maven
-          server-id: central
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+        **Maven:**
+        ```xml
+        <dependency>
+            <groupId>io.github.wphillipmoore</groupId>
+            <artifactId>mq-rest-admin</artifactId>
+            <version>$VERSION</version>
+        </dependency>
+        ```
 
-      - name: Extract version
-        id: version
-        run: |
-          version=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+        **Gradle:**
+        ```groovy
+        implementation 'io.github.wphillipmoore:mq-rest-admin:$VERSION'
+        ```
 
-      - name: Check if tag already exists
-        id: tag_check
-        run: |
-          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
+        ## Links
 
-      - name: Build and validate
-        if: steps.tag_check.outputs.exists == 'false'
-        run: ./mvnw verify -B
-
-      - name: Attest build provenance
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: actions/attest-build-provenance@v3
-        with:
-          subject-path: "target/*.jar"
-
-      - name: Generate SBOM
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/security/trivy@develop
-        with:
-          scan-type: sbom
-          output-file: target/mq-rest-admin-${{ steps.version.outputs.version }}.cdx.json
-
-      - name: Tag and release
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@develop
-        with:
-          version: ${{ steps.version.outputs.version }}
-          release-title: mq-rest-admin
-          release-notes: |
-            ## Installation
-
-            **Maven:**
-            ```xml
-            <dependency>
-                <groupId>io.github.wphillipmoore</groupId>
-                <artifactId>mq-rest-admin</artifactId>
-                <version>${{ steps.version.outputs.version }}</version>
-            </dependency>
-            ```
-
-            **Gradle:**
-            ```groovy
-            implementation 'io.github.wphillipmoore:mq-rest-admin:${{ steps.version.outputs.version }}'
-            ```
-
-            ## Links
-
-            - [Maven Central](https://central.sonatype.com/artifact/io.github.wphillipmoore/mq-rest-admin)
-            - [Documentation](https://wphillipmoore.github.io/mq-rest-admin-java/)
-          release-artifacts: target/mq-rest-admin-${{ steps.version.outputs.version }}.cdx.json
-
-      - name: Publish to Maven Central
-        if: steps.tag_check.outputs.exists == 'false' && env.HAS_MAVEN_CREDENTIALS == 'true'
-        run: ./mvnw deploy -B -Prelease -DskipTests
-        env:
-          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
-      - name: Generate app token for bump PR
-        if: steps.tag_check.outputs.exists == 'false'
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: Version bump PR
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@develop
-        with:
-          current-version: ${{ steps.version.outputs.version }}
-          version-file: pom.xml
-          version-regex: '(<artifactId>mq-rest-admin</artifactId>\s*<version>)[^<]+(</version>)'
-          version-replacement: '\g<1>{version}\2'
-          develop-version-command: grep -m1 '<version>' | sed 's/.*<version>\(.*\)<\/version>.*/\1/'
-          app-token: ${{ steps.app-token.outputs.token }}
+        - [Maven Central](https://central.sonatype.com/artifact/io.github.wphillipmoore/mq-rest-admin)
+        - [Documentation](https://wphillipmoore.github.io/mq-rest-admin-java/)
+      release-artifacts: "dist/*"
+      version-file: pom.xml
+      version-regex: '(<artifactId>mq-rest-admin</artifactId>\s*<version>)[^<]+(</version>)'
+      version-replacement: '\g<1>{version}\2'
+      version-regex-multiline: "true"
+      develop-version-command: >-
+        grep -m1 '<version>' | sed 's/.*<version>\(.*\)<\/version>.*/\1/'
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+      CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,2 +1,4 @@
 CHANGELOG.md
 releases/
+AGENTS.md
+CLAUDE.md


### PR DESCRIPTION
## Summary

- Replace per-repo publish.yml with thin caller that delegates to the shared `publish-release.yml` reusable workflow in standard-actions
- All ecosystem-specific behavior is passed as inputs to the shared workflow
- Consistent action refs, step ordering, and SBOM output normalization

Ref wphillipmoore/standard-actions#171

## Test plan

- [ ] Verify CI passes on this branch
- [ ] After standard-actions#171 merges to develop, verify publish workflow runs correctly on next release
- [ ] Confirm idempotency: re-run on existing tag should skip all mutating steps
