### PR TITLE
ci: use dev-docs container for docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,7 @@ jobs:
   deploy:
     name: "deploy: docs"
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-docs:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
# Pull Request

## Summary

- Run docs workflow inside ghcr.io/wphillipmoore/dev-docs:latest
- Keep actions/setup-java step (installs JDK into the Debian-based container)
- Keep ./mvnw javadoc:javadoc step

## Issue Linkage

- Fixes #255

## Testing

- markdownlint
- ci: docs workflow passes with container
- ci: javadoc generates successfully inside container

## Notes

- Merge after standard-tooling-docker#27 and standard-actions#174
