### PR TITLE
chore: update CLAUDE.md for docker-only standard-tooling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@ Java wrapper for the IBM MQ administrative REST API, ported from `pymqrest` (Pyt
 
 - **Java**: 17+ (install via `brew install openjdk@17` or SDKMAN)
 - **Maven**: Provided by Maven Wrapper (`./mvnw`), no separate install needed
-- **Standard tooling**: `cd ../standard-tooling && uv sync && export PATH="../standard-tooling/.venv/bin:../standard-tooling/scripts/bin:$PATH"`
+- **Git hooks**: `git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks`
+- **Standard tooling**: CLI tools (`st-commit`, `st-validate-local`, etc.) are pre-installed in the dev container images
 
 ### Three-Tier CI Model
 


### PR DESCRIPTION
## Summary

- Remove manual standard-tooling setup (uv sync, PATH manipulation) from CLAUDE.md
- Standard-tooling CLI tools are now pre-installed in dev container images
- Keep git hooks configuration (runs locally, not in container)

## Test plan

- [ ] CI passes

Closes #256
Ref wphillipmoore/standard-tooling#213

🤖 Generated with [Claude Code](https://claude.com/claude-code)