### PR TITLE
chore: use st-docker-test instead of legacy docker-test wrapper

### DIFF
--- a/scripts/dev/audit.sh
+++ b/scripts/dev/audit.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-java:21}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-./mvnw dependency:tree -B -q && ./mvnw org.codehaus.mojo:license-maven-plugin:2.7.0:add-third-party -Dlicense.excludedScopes=test -Dlicense.failIfWarning=true '-Dlicense.includedLicenses=Apache-2.0|Apache 2.0|The Apache License, Version 2.0|MIT License|BSD-2-Clause|BSD-3-Clause|ISC|MPL-2.0|GPL-3.0-or-later' -B}"
 
-if ! command -v docker-test >/dev/null 2>&1; then
-  echo "ERROR: docker-test not found on PATH." >&2
-  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+if ! command -v st-docker-test >/dev/null 2>&1; then
+  echo "ERROR: st-docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/.venv/bin:\$PATH" >&2
   exit 1
 fi
-exec docker-test
+exec st-docker-test

--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-java:21}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-./mvnw spotless:check checkstyle:check -B}"
 
-if ! command -v docker-test >/dev/null 2>&1; then
-  echo "ERROR: docker-test not found on PATH." >&2
-  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+if ! command -v st-docker-test >/dev/null 2>&1; then
+  echo "ERROR: st-docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/.venv/bin:\$PATH" >&2
   exit 1
 fi
-exec docker-test
+exec st-docker-test

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-java:21}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-./mvnw verify -B}"
 
-if ! command -v docker-test >/dev/null 2>&1; then
-  echo "ERROR: docker-test not found on PATH." >&2
-  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+if ! command -v st-docker-test >/dev/null 2>&1; then
+  echo "ERROR: st-docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/.venv/bin:\$PATH" >&2
   exit 1
 fi
-exec docker-test
+exec st-docker-test

--- a/scripts/dev/typecheck.sh
+++ b/scripts/dev/typecheck.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-java:21}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-./mvnw compile -B}"
 
-if ! command -v docker-test >/dev/null 2>&1; then
-  echo "ERROR: docker-test not found on PATH." >&2
-  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+if ! command -v st-docker-test >/dev/null 2>&1; then
+  echo "ERROR: st-docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/.venv/bin:\$PATH" >&2
   exit 1
 fi
-exec docker-test
+exec st-docker-test


### PR DESCRIPTION
# Pull Request

## Summary

- Update scripts/dev/*.sh to use st-docker-test instead of legacy docker-test wrapper, and update PATH hint from scripts/bin to .venv/bin.

## Issue Linkage

- Fixes #259

## Testing

- markdownlint
- `./mvnw verify`

## Notes

- -