### PR TITLE
chore(ci): migrate standard-actions refs from @develop to @v1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
   # Security and standards (shared reusable workflow)
   # ---------------------------------------------------------------------------
   security-and-standards:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@develop
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.3
     with:
       language: java
       run-standards: ${{ inputs.run-release-gates || 'true' }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Version divergence gate (PRs targeting develop)
         if: github.event_name == 'pull_request' && github.base_ref == 'develop'
-        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@develop
+        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.3
         with:
           head-version-command: ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout
           main-version-command: git show origin/main:pom.xml | grep -m1 '<version>' | sed 's/.*<version>\(.*\)<\/version>.*/\1/'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
         run: ./mvnw javadoc:javadoc -B -q
 
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.3
         with:
           version-command: ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | sed 's/-SNAPSHOT//' | cut -d. -f1,2
           checkout-common: "true"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   publish:
-    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@develop
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.3
     permissions:
       attestations: write
       contents: write


### PR DESCRIPTION
# Pull Request

## Summary

- Migrate standard-actions refs from @develop to @v1.3

## Issue Linkage

- Closes #265

## Testing

- markdownlint
- `./mvnw verify`

## Notes

- Pins all standard-actions refs to @v1.3 rolling minor tag. Tracking: standard-actions#145.