### PR TITLE
chore(ci): replace retired dev-docs image with dev-base in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
   deploy:
     name: "deploy: docs"
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-docs:latest
+    container: ghcr.io/wphillipmoore/dev-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
# Pull Request

## Summary

- Replace retired dev-docs container image with dev-base in docs workflow

## Issue Linkage

- Ref #273

## Testing

- markdownlint
- `./mvnw verify`

## Notes

- Part of wphillipmoore/standard-tooling#430