### PR TITLE
fix(ci): specify language, container-tag, and registry-publish in publish-release caller

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,4 +13,8 @@ permissions:
 jobs:
   publish:
     uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
+    with:
+      language: java
+      container-tag: "17"
+      registry-publish: true
     secrets: inherit


### PR DESCRIPTION
# Pull Request

## Summary

- Specify language: java, container-tag: 17, and registry-publish: true for Maven Central publishing

## Issue Linkage

- Ref wphillipmoore/standard-actions#412

## Testing

- `st-docker-run -- st-validate`
- `./mvnw verify`

## Notes

- -