### PR TITLE
chore(tooling): migrate to vergil v2.1

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,8 @@
     "vergil-marketplace": {
       "source": {
         "source": "github",
-        "repo": "vergil-project/vergil-claude-plugin"
+        "repo": "vergil-project/vergil-claude-plugin",
+        "ref": "v2.1"
       }
     }
   },

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   docs:
-    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.1
     with:
       pre-deploy-command: >-
         git clone --depth 1 --branch develop
@@ -25,7 +25,7 @@ jobs:
 
   release:
     if: github.ref == 'refs/heads/main'
-    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.1
     with:
       language: java
       container-tag: "17"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   audit:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@v2.1
     with:
       language: java
       versions: ${{ inputs.java-versions || '["17", "21"]' }}
@@ -84,13 +84,13 @@ jobs:
         run: ./mvnw verify -B
 
   quality:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.1
     with:
       language: java
       versions: ${{ inputs.java-versions || '["17", "21"]' }}
 
   security:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.1
     with:
       language: java
       run-standards: ${{ inputs.run-release != 'false' }}
@@ -100,14 +100,14 @@ jobs:
       security-events: write
 
   test:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@v2.1
     with:
       language: java
       versions: ${{ inputs.java-versions || '["17", "21"]' }}
       container-suffix: java
 
   version:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.1
     with:
       language: java
       run-release: ${{ inputs.run-release != 'false' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -98,6 +99,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
 
   test:
     uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@v2.1

--- a/vergil.toml
+++ b/vergil.toml
@@ -17,4 +17,4 @@ release = true
 docs = true
 
 [dependencies]
-vergil = "v2.0"
+vergil = "v2.1"


### PR DESCRIPTION
# Pull Request

## Summary

- Migrate mq-rest-admin-java tooling and workflow refs from vergil v2.0 to v2.1 and grant actions: read to the ci-security caller.

## Issue Linkage

- Ref #316

## Notes

- Scope: vergil.toml dep, 7 workflow refs bumped (ci.yml x5, cd.yml x2), .claude/settings.json marketplace ref set to v2.1. actions: read added to ci.yml top-level and security job permissions because v2.1 ci-security.yml (vergil-actions#698; v2.1 resolves to v2.1.5) requests actions: read from callers; without it the PR fails at startup. Version divergence: VERSION is 1.2.2 vs latest release tag v1.2.1 (one patch ahead, noted only, not bumped). repo-config audit local: compliant. vrg-validate GREEN.